### PR TITLE
res: portability improvements for uclibc

### DIFF
--- a/include/resolv.h
+++ b/include/resolv.h
@@ -57,7 +57,7 @@
 
 #define RES_DEFAULT	(RES_RECURSE | RES_DEFNAMES | RES_DNSRCH)
 
-#if ((__GNU_LIBRARY__ == 6) && (__GLIBC__ >= 2) && (__GLIBC_MINOR__ >= 3))
+#if ((__GNU_LIBRARY__ == 6) && (__GLIBC__ >= 2) && (__GLIBC_MINOR__ >= 3)) || defined(__UCLIBC__)
 # define MAXRESOLVSORT		10	/* number of net to sort on */
 
 struct __res_state {

--- a/src/res.c
+++ b/src/res.c
@@ -878,10 +878,8 @@ static int proc_answer(ResRQ * rptr, HEADER *hptr, char *buf, char *eob)
 
 	hostbuf[RES_HOSTLEN] = '\0';
 	cp += n;
-	type = (int) _getshort(cp);
-       cp += TYPE_SIZE;
-	class = (int) _getshort(cp);
-       cp += CLASS_SIZE;
+	GETSHORT(type, cp);
+	GETSHORT(class, cp);
 	if(class != C_IN)
 	{
 	    sendto_realops_lev(DEBUG_LEV,
@@ -972,16 +970,11 @@ static int proc_answer(ResRQ * rptr, HEADER *hptr, char *buf, char *eob)
 	if (n <= 0)
 	    break;
 	cp += n;
-	type = (int) _getshort(cp);
-       cp += TYPE_SIZE;
+	GETSHORT(type, cp);
+	GETSHORT(class, cp);
 	
-	class = (int) _getshort(cp);
-       cp += CLASS_SIZE;
-	
-	rptr->ttl = _getlong(cp);
-       cp += TTL_SIZE;
-	dlen = (int) _getshort(cp);
-       cp += DLEN_SIZE;
+	GETLONG(rptr->ttl, cp);
+	GETSHORT(dlen, cp);
 	
 	/* Wait to set rptr->type until we verify this structure */
 


### PR DESCRIPTION
This allows building Bahamut on uClibc without any modification.  It avoids using
deprecated interfaces in POSIX-2008, such as _getshort(), _getlong() and directly
dereferencing _res (instead, __res_state() should be dereferenced).
