### PR TITLE
USE_SSL always on even when target server does not have openssl installed

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -565,9 +565,11 @@
 /*
  * USE_SSL - Add SSL support for users
  */
-#define USE_SSL
-#define IRCDSSL_KPATH "ircd.key"
-#define IRCDSSL_CPATH "ircd.crt"
+#ifdef HAVE_ENCRYPTION_ON
+                        #define USE_SSL
+                        #define IRCDSSL_KPATH "ircd.key"
+                        #define IRCDSSL_CPATH "ircd.crt"
+#endif
 
 /******************************************************************
  * STOP STOP STOP STOP STOP STOP STOP STOP STOP STOP STOP STOP STOP


### PR DESCRIPTION
Updated config.h to reflect check for HAVE_ENCRYPTION_ON

Chris White/phreakshow
