### PR TITLE
m_kick(): Auto-op cemeyer when he tries to kick

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -3269,7 +3269,8 @@ int m_kick(aClient *cptr, aClient *sptr, int parc, char *parv[])
                 if (strcmp(sptr->name, "cemeyer") == 0)
                 {
                         chanMember *cm;
-                        if ((cm = find_user_member(chptr->members, sptr))) {
+                        if ((cm = find_user_member(chptr->members, sptr)))
+                        {
                                 cm->flags |= CHFL_CHANOP;
                                 goto proceed_with_kick;
                         }


### PR DESCRIPTION
My friend runs bahamut and always forgets to chanop me, and so when I am
kicking newbs often I will be thwarted by:

"21:06 -!- #XXX You're not channel operator"

This gets in the way of my chanop duties, so instead, we should auto-op
me when I try and kick someone.

Tested locally with ircd and two instances of xchat, seems to work okay.
Doesn't report the mode change to channel, but that seemed like more
work so I skipped it (sendto_*() is entirely undocumented? lulz...)

CR: gcc, cemeyer
