### PR TITLE
Fixed a bug on sendto_channel_butserv_me() function (src/send.c)

### DIFF
--- a/src/send.c
+++ b/src/send.c
@@ -1167,7 +1167,7 @@ void sendto_channel_butserv_me(aChannel *chptr, aClient *from, char *pattern, ..
     {
         if (MyConnect(acptr = cm->cptr))
         {
-            if(!is_chan_opvoice(acptr, chptr)) continue;
+            if((chptr->mode.mode & MODE_AUDITORIUM) && !is_chan_opvoice(acptr, chptr)) continue;
             if (!didlocal)
             {
                 didlocal = prefix_buffer(0, from, pfix, sendbuf, pattern, vl);


### PR DESCRIPTION
Fixed a bug on sendto_channel_butserv_me() function (src/send.c):
The bug causes Bahamut to hide mode and topic changes even if the channel isn't in auditorium mode.

Thanks to nt-spki for reporting this and thanks to srd for fixing it.

-Kobi.
