### PR TITLE
Attempt at adding server-to-server SSL

### DIFF
--- a/include/h.h
+++ b/include/h.h
@@ -380,6 +380,7 @@ int ssl_rehash();
 int safe_ssl_read(aClient *, void *, int);
 int safe_ssl_write(aClient *, const void *, int);
 int safe_ssl_accept(aClient *, int);
+int safe_ssl_connect(aClient *, int);
 int ssl_smart_shutdown(SSL *);
 #endif
 

--- a/include/struct.h
+++ b/include/struct.h
@@ -678,9 +678,10 @@ typedef struct Whowas
 
 /* flags for connects */
 
-#define CONN_ZIP 	0x001	/* zippable    */
-#define CONN_DKEY	0x010	/* cryptable   */
-#define CONN_HUB	0x100	/* hubbable!   */
+#define CONN_ZIP 	0x0001	/* zippable!   */
+#define CONN_DKEY	0x0010	/* cryptable!  */
+#define CONN_HUB	0x0100	/* hubbable!   */
+#define CONN_SSL	0x1000	/* SSLable!    */
 
 /* U:line flags in Server struct */
 

--- a/src/m_server.c
+++ b/src/m_server.c
@@ -172,10 +172,11 @@ do_server_estab(aClient *cptr)
 
     fakelinkserver_update(cptr->name, cptr->info);
 
-    sendto_gnotice("from %s: Link with %s established, states:%s%s%s%s",
+    sendto_gnotice("from %s: Link with %s established, states:%s%s%s%s%s",
                    me.name, inpath, ZipOut(cptr) ? " Output-compressed" : "",
                    RC4EncLink(cptr) ? " encrypted" : "",
                    IsULine(cptr) ? " ULined" : "",
+                   IsSSL(cptr) ? " SSL" : "",
                    DoesTS(cptr) ? " TS" : " Non-TS");
 
     /*
@@ -184,9 +185,11 @@ do_server_estab(aClient *cptr)
      * me->serv and the other between serv->me
      */
 
-    sendto_serv_butone(NULL, ":%s GNOTICE :Link with %s established: %s",
-                       me.name, inpath,
-                       DoesTS(cptr) ? "TS link" : "Non-TS link!");
+    sendto_serv_butone(NULL, ":%s GNOTICE :Link with %s established: %s%s%s%s",
+                   me.name, inpath, ZipOut(cptr) ? " Output-compressed" : "",
+                   RC4EncLink(cptr) ? " encrypted" : "",
+                   IsSSL(cptr) ? " SSL" : "",
+                   DoesTS(cptr) ? " TS" : " Non-TS");
 
     add_to_client_hash_table(cptr->name, cptr);
 

--- a/src/s_conf.c
+++ b/src/s_conf.c
@@ -770,6 +770,7 @@ static int server_info[] =
 {
     CONN_ZIP, 'Z',
     CONN_DKEY, 'E',
+    CONN_SSL, 'S',
     CONN_HUB, 'H',
     0, 0
 };


### PR DESCRIPTION
In my fork of Bahamut, I have been toying with server-to-server SSL, and decided it would be cool to contribute those specific changes back to you, even though your network has me A-banned (last I checked you did, anyway). If you'd like me to visit, say, a testnet, just drop me a line in this pull request.
## Rationale

Most IRCds in use today (namely Unreal and Charybdis) support SSL encryption of server-to-server links. Older IRCds use RC4 (like in Bahamut's instance) or some weird SERVLINK thing (in Hybrid7's case). This patch, if it actually works, brings Bahamut back up to date with modern IRC link encryption.
