### PR TITLE
Let IRC Operators (both local and global) see cmode +j's settings

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -1322,14 +1322,14 @@ static void channel_modes(aClient *cptr, char *mbuf, char *pbuf,
     if (chptr->mode.limit) 
     {
         *mbuf++ = 'l';
-        if (IsMember(cptr, chptr) || IsServer(cptr) || IsULine(cptr) || IsOper(cptr))
+        if (IsMember(cptr, chptr) || IsServer(cptr) || IsULine(cptr) || IsAnOper(cptr))
             ircsprintf(pbuf, "%d", chptr->mode.limit);
     }
     if (chptr->mode.mode & MODE_JOINRATE)
     {
         *mbuf++ = 'j';
 
-        if (IsMember(cptr, chptr) || IsServer(cptr) || IsULine(cptr))
+        if (IsMember(cptr, chptr) || IsServer(cptr) || IsULine(cptr) || IsAnOper(cptr))
         {
             char tmp[16];
             if(pbuf[0] != '\0')


### PR DESCRIPTION
Let IRC Operators (both local and global) see cmode +j's settings with /mode #channel from outside the channel in addition to +l.