### PR TITLE
Decrease MAXBANS from 500 back to 200

### DIFF
--- a/include/struct.h
+++ b/include/struct.h
@@ -135,7 +135,7 @@ typedef struct SServicesTag ServicesTag;
 #define	KEYLEN		    23
 #define	BUFSIZE		    512	/* WARNING: *DONT* CHANGE THIS!!!! */
 #define	MAXRECIPIENTS       20
-#define	MAXBANS	 	    500
+#define	MAXBANS	 	    200
 #define MAXINVITELIST       100
 #define MAXEXEMPTLIST       100
 


### PR DESCRIPTION
Per our IRC discussion, it would probably be safer to first check the impact on the queues (i.e. sendq) before increasing this limit globally.

Also, we now have the ability to increase MAXBANS for individual channels that really need it (via services extended flags).

-Kobi.