### PR TITLE
New module hooks

### DIFF
--- a/include/hooks.h
+++ b/include/hooks.h
@@ -16,6 +16,12 @@ enum c_hooktype {
                        * Params: 1: (aClient *) 
                        * Returns int
                        */
+   CHOOK_ONACCESS,    /* called during m_user 
+                       * (after CHOOK_PREACCESS and before CHOOK_POSTACCESS)
+                       * Params: 5: (aClient *, char *username, char *host,
+                       *             char *server, char *realname) 
+                       * Returns int
+                       */
    CHOOK_POSTACCESS,  /* called after access checks are done 
                        * (right before client is put on network)
                        * Params: 1: (aClient *) 

--- a/include/hooks.h
+++ b/include/hooks.h
@@ -80,6 +80,11 @@ enum c_hooktype {
                        *             int type, char *cmd, char *reason)
                        * Returns int
                        */
+   CHOOK_SPAMWARN,    /* called from s_user.c and channel.c during spam warnings to opers
+                       * Params: 4: (aClient *source, int type, int max_targets,
+                       *             char *target_name)
+                       * Returns int
+                       */
    CHOOK_SIGNOFF,     /* called on client exit (exit_client)
                        * Params: 1: (aClient *)
                        * Returns void */

--- a/src/channel.c
+++ b/src/channel.c
@@ -3149,9 +3149,10 @@ int m_join(aClient *cptr, aClient *sptr, int parc, char *parv[])
             {
                 if (sptr->join_leave_count >= spam_num)
                 {
-                    sendto_realops_lev(SPAM_LEV, "User %s (%s@%s) is a "
-                                   "possible spambot", sptr->name,
-                                   sptr->user->username, sptr->user->host);
+                    if(call_hooks(CHOOK_SPAMWARN, sptr, 2, spam_num, NULL) != FLUSH_BUFFER)
+                        sendto_realops_lev(SPAM_LEV, "User %s (%s@%s) is a "
+                                       "possible spambot", sptr->name,
+                                       sptr->user->username, sptr->user->host);
                     sptr->oper_warn_count_down = OPER_SPAM_COUNTDOWN;
                 }
                 else
@@ -3240,12 +3241,13 @@ int m_join(aClient *cptr, aClient *sptr, int parc, char *parv[])
                 
                 if (sptr->oper_warn_count_down == 0)
                 {
-                    sendto_realops_lev(SPAM_LEV, "User %s (%s@%s) trying to "
-                                   "join %s is a possible spambot",
-                                   sptr->name,
-                                   sptr->user->username,
-                                   sptr->user->host,
-                                   name);
+                    if(call_hooks(CHOOK_SPAMWARN, sptr, 3, spam_num, name) != FLUSH_BUFFER)
+                        sendto_realops_lev(SPAM_LEV, "User %s (%s@%s) trying to "
+                                       "join %s is a possible spambot",
+                                       sptr->name,
+                                       sptr->user->username,
+                                       sptr->user->host,
+                                       name);
                     sptr->oper_warn_count_down = OPER_SPAM_COUNTDOWN;
                 }
 # ifndef ANTI_SPAMBOT_WARN_ONLY
@@ -3452,9 +3454,10 @@ int m_part(aClient *cptr, aClient *sptr, int parc, char *parv[])
     {
         if (sptr->join_leave_count >= spam_num)
         {
-            sendto_realops_lev(SPAM_LEV, "User %s (%s@%s) is a possible"
-                        " spambot", sptr->name, sptr->user->username, 
-                        sptr->user->host);
+            if(call_hooks(CHOOK_SPAMWARN, sptr, 4, spam_num, NULL) != FLUSH_BUFFER)
+                sendto_realops_lev(SPAM_LEV, "User %s (%s@%s) is a possible"
+                            " spambot", sptr->name, sptr->user->username, 
+                            sptr->user->host);
             sptr->oper_warn_count_down = OPER_SPAM_COUNTDOWN;
         }
         else

--- a/src/modules.c
+++ b/src/modules.c
@@ -478,6 +478,7 @@ typedef struct module_hook
 } aHook;
 
 static DLink *preaccess_hooks = NULL;
+static DLink *onaccess_hooks = NULL;
 static DLink *postaccess_hooks = NULL;
 static DLink *postmotd_hooks = NULL;
 static DLink *msg_hooks = NULL;
@@ -511,6 +512,9 @@ get_texthooktype(enum c_hooktype hooktype)
 
         case CHOOK_PREACCESS:
             return "Pre-access";
+
+        case CHOOK_ONACCESS:
+            return "On-access";
 
         case CHOOK_POSTACCESS:
             return "Post-access";
@@ -582,6 +586,10 @@ get_hooklist(enum c_hooktype hooktype)
 
         case CHOOK_PREACCESS:
             hooklist = &preaccess_hooks;
+            break;
+
+        case CHOOK_ONACCESS:
+            hooklist = &onaccess_hooks;
             break;
 
         case CHOOK_POSTACCESS:
@@ -761,6 +769,24 @@ call_hooks(enum c_hooktype hooktype, ...)
                 {
                     int (*rfunc) (aClient *) = ((aHook *)lp->value.cp)->funcptr;
                     if((ret = (*rfunc)(acptr)) == FLUSH_BUFFER)
+                        break;
+                }
+                break;
+            }
+
+        case CHOOK_ONACCESS:
+            {
+                aClient *acptr = va_arg(vl, aClient *);
+                char *username = va_arg(vl, char *);
+                char *host = va_arg(vl, char *);
+                char *server = va_arg(vl, char *);
+                char *realname = va_arg(vl, char *);
+
+                for(lp = onaccess_hooks; lp; lp = lp->next)
+                {
+                    int (*rfunc) (aClient *, char *, char *, char *, char *) =
+                                    ((aHook *)lp->value.cp)->funcptr;
+                    if((ret = (*rfunc)(acptr, username, host, server, realname)) == FLUSH_BUFFER)
                         break;
                 }
                 break;
@@ -1099,6 +1125,7 @@ memcount_modules(MCmodules *mc)
     mc->e_dlinks += c;
 
     mc->e_dlinks += mc_dlinks(preaccess_hooks);
+    mc->e_dlinks += mc_dlinks(onaccess_hooks);
     mc->e_dlinks += mc_dlinks(postaccess_hooks);
     mc->e_dlinks += mc_dlinks(postmotd_hooks);
     mc->e_dlinks += mc_dlinks(msg_hooks);

--- a/src/s_user.c
+++ b/src/s_user.c
@@ -2239,6 +2239,7 @@ m_user(aClient *cptr, aClient *sptr, int parc, char *parv[])
         int loc = (ban->flags & SBAN_LOCAL) ? 1 : 0;
         return exit_banned_client(cptr, loc, 'G', ban->reason, 0);
     }
+    if(call_hooks(CHOOK_ONACCESS, cptr, username, host, server, realname) == FLUSH_BUFFER) return 0;
     return do_user(parv[0], cptr, sptr, username, host, server, 0,0, realname);
 }
 

--- a/src/s_user.c
+++ b/src/s_user.c
@@ -1407,17 +1407,20 @@ int check_target_limit(aClient *sptr, aClient *acptr)
     {
         sendto_one(sptr, err_str(ERR_TARGETTOFAST), me.name, sptr->name,
                    acptr->name, MSG_TARGET_TIME - tmin);
-        sptr->since += 2; /* penalize them 2 seconds for this! */
-        sptr->num_target_errors++;
-
-        if(sptr->last_target_complain + 60 <= NOW)
+        if(call_hooks(CHOOK_SPAMWARN, sptr, 1, max_targets, NULL) != FLUSH_BUFFER)
         {
-            sendto_realops_lev(SPAM_LEV, "Target limited: %s (%s@%s)"
-                               " [%d failed targets]", sptr->name,
-                                sptr->user->username, sptr->user->host, 
-                                sptr->num_target_errors);
-            sptr->num_target_errors = 0;
-            sptr->last_target_complain = NOW;
+            sptr->since += 2; /* penalize them 2 seconds for this! */
+            sptr->num_target_errors++;
+
+            if(sptr->last_target_complain + 60 <= NOW)
+            {
+                sendto_realops_lev(SPAM_LEV, "Target limited: %s (%s@%s)"
+                                   " [%d failed targets]", sptr->name,
+                                    sptr->user->username, sptr->user->host, 
+                                    sptr->num_target_errors);
+                sptr->num_target_errors = 0;
+                sptr->last_target_complain = NOW;
+            }
         }
         return 1;
     }


### PR DESCRIPTION
CHOOK_SPAMWARN is called from s_user.c and channel.c during spam warnings to opers
Params: 4: (aClient *source, int type, int max_targets, char *target_name)

CHOOK_ONACCESS is called from s_user.c during m_user
(in general, it is called before CHOOK_POSTACCESS and after CHOOK_PREACCESS)
Params: 5: (aClient *, char *username, char *host, char *server, char *realname)
Returns: int (FLUSH_BUFFER can block the m_user call)