### PR TITLE
Changes for Bahamut 2.1.2

### DIFF
--- a/include/h.h
+++ b/include/h.h
@@ -262,7 +262,7 @@ extern aClient 	 *next_client_double(aClient *, char *);
 
 extern int  	  m_umode(aClient *, aClient *, int, char **);
 extern int  	  m_names(aClient *, aClient *, int, char **);
-extern void 	  send_umode(aClient *, aClient *, int, int, char *);
+extern void 	  send_umode(aClient *, aClient *, long, long, char *, int);
 extern int 	  del_silence(aClient *, char *);
 
 

--- a/include/numeric.h
+++ b/include/numeric.h
@@ -153,6 +153,7 @@
 #define	RPL_ENDOFINFO        374
 #define	RPL_MOTDSTART        375
 #define	RPL_ENDOFMOTD        376
+#define RPL_WHOISMODES       379
 
 #define RPL_YOUREOPER        381
 #define RPL_REHASHING        382

--- a/include/struct.h
+++ b/include/struct.h
@@ -610,7 +610,7 @@ typedef struct Whowas
     char       *servername;
     char        realname[REALLEN + 1];
     time_t      logoff;
-    unsigned int umode;
+    long umode;
     struct Client *online;  /* Pointer to new nickname for chasing or NULL */
     
     struct Whowas *next;    /* for hash table... */
@@ -904,7 +904,11 @@ struct Client
     time_t      since;      /* last time we parsed something */
     ts_val      tsinfo;     /* TS on the nick, SVINFO on servers */
     long        flags;      /* client flags */
-    long        umode;      /* We can illeviate overflow this way */
+    long        umode;      /* We can illeviate overflow this way
+                               Note: if you change this, you need to also
+                               change struct SearchOptions,
+                               struct Whowas and struct SServicesTag -Kobi.
+                             */
     aClient    *from;       /* == self, if Local Client, *NEVER* NULL! */
     aClient    *uplink;     /* this client's uplink to the network */
     int         fd;         /* >= 0, for local clients */
@@ -1487,7 +1491,7 @@ struct ListOptions
 
 typedef struct SearchOptions 
 {
-    int umodes;
+    long umodes;
     char *nick;
     char *user;
     char *host;

--- a/include/struct.h
+++ b/include/struct.h
@@ -296,6 +296,7 @@ typedef struct SServicesTag ServicesTag;
 #define UMODE_f     0x00100	/* umode +f - Server flood messages */
 #define UMODE_y     0x00200	/* umode +y - Stats/links */
 #define UMODE_d     0x00400	/* umode +d - Debug info */
+/* 0x00800 is free */
 #define UMODE_g     0x01000	/* umode +g - Globops */
 #define UMODE_b     0x02000	/* umode +b - Chatops */
 #define UMODE_a     0x04000	/* umode +a - Services Admin */

--- a/include/struct.h
+++ b/include/struct.h
@@ -296,7 +296,7 @@ typedef struct SServicesTag ServicesTag;
 #define UMODE_f     0x00100	/* umode +f - Server flood messages */
 #define UMODE_y     0x00200	/* umode +y - Stats/links */
 #define UMODE_d     0x00400	/* umode +d - Debug info */
-/* 0x00800 is free */
+#define UMODE_P     0x00800     /* umode +P - User wants extra privacy (no spamfilter) */
 #define UMODE_g     0x01000	/* umode +g - Globops */
 #define UMODE_b     0x02000	/* umode +b - Chatops */
 #define UMODE_a     0x04000	/* umode +a - Services Admin */
@@ -316,7 +316,8 @@ typedef struct SServicesTag ServicesTag;
 #define UMODE_S     0x10000000  /* umode +S - User is using SSL */
 #define UMODE_C     0x20000000  /* umode +C - User is only accepting private messages from users who share a common channel with them */
 #define UMODE_H     0x40000000  /* umode +H - User is host-masked */
-#define UMODE_P     0x80000000  /* umode +P - User wants extra privacy (no spamfilter) */
+/* WARNING: Do not add any values greater than 0x40000000 unless you change Client->umode to unsigned long
+            (and change everything else to support it) -Kobi & xPsycho. */
 
 /* for sendto_ops_lev */
 

--- a/include/struct.h
+++ b/include/struct.h
@@ -1365,6 +1365,7 @@ struct Channel
 #define XFLAG_USER_VERBOSE      0x0800
 #define XFLAG_OPER_VERBOSE      0x1000
 #define XFLAG_SJR               0x2000 /* Services join request */
+#define XFLAG_NO_NICK_CHANGE    0x4000
 
 struct FlagList
 {

--- a/src/channel.c
+++ b/src/channel.c
@@ -3560,9 +3560,9 @@ int m_part(aClient *cptr, aClient *sptr, int parc, char *parv[])
 
         if (parc < 3 || can_send(sptr,chptr,reason) || IsSquelch(sptr) || ((chptr->xflags & XFLAG_NO_PART_MSG) && !is_xflags_exempted(sptr,chptr)))
         {
-            if(reason && (chptr->xflags & XFLAG_USER_VERBOSE))
+            if(reason && *reason && (chptr->xflags & XFLAG_USER_VERBOSE))
                 verbose_to_relaychan(cptr, chptr, "part_msg", reason);
-            if(reason && (chptr->xflags & XFLAG_OPER_VERBOSE))
+            if(reason && *reason && (chptr->xflags & XFLAG_OPER_VERBOSE))
                 verbose_to_opers(cptr, chptr, "part_msg", reason);
             sendto_serv_butone(cptr, PartFmt, parv[0], name);
             sendto_channel_butserv(chptr, sptr, PartFmt, parv[0], name);

--- a/src/channel.c
+++ b/src/channel.c
@@ -3913,6 +3913,9 @@ int m_topic(aClient *cptr, aClient *sptr, int parc, char *parv[])
             return 0;
     }
 
+    if(chptr->topic_time==ts && !mycmp(chptr->topic, topic) && !mycmp(chptr->topic_nick, tnick))
+        return 0; /* Don't spam the network if it's the same topic -Kobi_S */
+
     strncpyzt(chptr->topic, topic, TOPICLEN + 1);
     strcpy(chptr->topic_nick, tnick);
     chptr->topic_time = ts;

--- a/src/confparse.c
+++ b/src/confparse.c
@@ -123,7 +123,7 @@ check_quote(char *cur)
     if(quote)
     {
         while((cur = strchr(cur, '*')))
-            if((*(++cur) == '/'))
+            if(*(++cur) == '/')
             {
                 cur++;
                 quote = 0;
@@ -144,7 +144,7 @@ check_quote(char *cur)
         cur += 2;
         quote = 1;
         while((cur = strchr(cur, '*')))
-            if((*(++cur) == '/'))
+            if(*(++cur) == '/')
             {
                 cur++;
                 quote = 0;
@@ -282,7 +282,7 @@ parse_block(tConf *block, char *cur, FILE *file, int *lnum)
             {
                 while(!BadPtr(cur) && (*cur != ';'))
                 {
-                    if((*cur == ' '))
+                    if(*cur == ' ')
                     {
                         *cur = '\0';
                         if(vars[vnum]->loaded == 1)

--- a/src/m_nick.c
+++ b/src/m_nick.c
@@ -537,7 +537,7 @@ int m_nick(aClient *cptr, aClient *sptr, int parc, char *parv[])
 
 		    oldumode = sptr->umode;
 		    sptr->umode &= ~UMODE_r;
-		    send_umode(sptr, sptr, oldumode, ALL_UMODES, mbuf);
+		    send_umode(sptr, sptr, oldumode, ALL_UMODES, mbuf, sizeof(mbuf));
 		}
 
                 /* LOCAL NICKHANGE */

--- a/src/m_server.c
+++ b/src/m_server.c
@@ -42,7 +42,7 @@ extern int uhm_type;
 static void sendnick_TS(aClient *cptr, aClient *acptr)
 {
     ServicesTag *servicestag;
-    static char ubuf[30];
+    static char ubuf[54];
     int *s, flag, i;
 
     if (IsPerson(acptr))

--- a/src/m_server.c
+++ b/src/m_server.c
@@ -47,7 +47,7 @@ static void sendnick_TS(aClient *cptr, aClient *acptr)
 
     if (IsPerson(acptr))
     {
-        send_umode(NULL, acptr, 0, SEND_UMODES, ubuf);
+        send_umode(NULL, acptr, 0, SEND_UMODES, ubuf, sizeof(ubuf));
         if (!*ubuf)     /* trivial optimization - Dianora */
         {
             ubuf[0] = '+';

--- a/src/m_services.c
+++ b/src/m_services.c
@@ -826,6 +826,7 @@ struct FlagList xflags_list[] =
   { "EXEMPT_REGISTERED", XFLAG_EXEMPT_REGISTERED },
   { "EXEMPT_INVITES",    XFLAG_EXEMPT_INVITES    },
   { "HIDE_MODE_LISTS",   XFLAG_HIDE_MODE_LISTS   },
+  { "NO_NICK_CHANGE",    XFLAG_NO_NICK_CHANGE    },
   { "SJR",               XFLAG_SJR               },
   { "USER_VERBOSE",      XFLAG_USER_VERBOSE      },
   { "OPER_VERBOSE",      XFLAG_OPER_VERBOSE      },
@@ -855,6 +856,7 @@ struct FlagList xflags_list[] =
  *   NO_QUIT_MSG       - no /quit messages (on/off)
  *   HIDE_MODE_LISTS   - hide /mode #channel +b/+I/+e lists from non-ops (on/off)
  *   SJR               - enable services join request for this channel (must also be enabled globally) 
+ *   NO_NICK_CHANGE    - no nick changes allowed on this channel (on/off)
  *   EXEMPT_OPPED      - exempt opped users (on/off)
  *   EXEMPT_VOICED     - exempt voiced users (on/off)
  *   EXEMPT_IDENTD     - exempt users with identd (on/off)

--- a/src/m_services.c
+++ b/src/m_services.c
@@ -229,7 +229,7 @@ int m_svsnick(aClient *cptr, aClient *sptr, int parc, char *parv[])
 	oldumode = acptr->umode;
 	acptr->umode &= ~UMODE_r;
 
-        send_umode(acptr, acptr, oldumode, ALL_UMODES, mbuf);
+        send_umode(acptr, acptr, oldumode, ALL_UMODES, mbuf, sizeof(mbuf));
     }
 
     acptr->tsinfo = atoi(parv[3]);
@@ -460,7 +460,7 @@ int m_svsmode(aClient *cptr, aClient *sptr, int parc, char *parv[])
     if (MyClient(acptr) && (oldumode != acptr->umode))
     {
         char buf[BUFSIZE];
-        send_umode(acptr, acptr, oldumode, ALL_UMODES, buf);
+        send_umode(acptr, acptr, oldumode, ALL_UMODES, buf, sizeof(buf));
     }
 
     return 0;

--- a/src/m_services.c
+++ b/src/m_services.c
@@ -414,9 +414,21 @@ int m_svsmode(aClient *cptr, aClient *sptr, int parc, char *parv[])
 		{
             if (what == MODE_ADD)
             {
-                /* no opering this way */
-                if (flag & (UMODE_o|UMODE_O))
-                    break;
+                if((flag & (UMODE_o|UMODE_O)) && !IsAnOper(acptr))
+                {
+                     Count.oper++;
+                     if(MyConnect(acptr))
+                         add_to_list(&oper_list, acptr);
+                }
+                if((flag & (UMODE_o|UMODE_O|UMODE_a|UMODE_A)) && optarg && MyConnect(acptr))
+                {
+                     if(*optarg == '+')
+                         acptr->oflag |= atol(optarg);
+                     else if(*optarg == '-')
+                         acptr->oflag &= ~(atol(optarg) * -1);
+                     else
+                         acptr->oflag = atol(optarg);
+                }
                 acptr->umode |= flag;
             }
             else if (acptr->umode & flag)

--- a/src/s_bsd.c
+++ b/src/s_bsd.c
@@ -1720,7 +1720,7 @@ void accept_connection(aListener *lptr)
             close(newfd);
             return;
         }
-        if((lptr->aport->legal == -1))
+        if(lptr->aport->legal == -1)
         {
             ircstp->is_ref++;
             send(newfd, "ERROR :This port is closed\r\n", 29, 0);

--- a/src/s_err.c
+++ b/src/s_err.c
@@ -418,7 +418,7 @@ static char *replies[] =
     /* 376 RPL_ENDOFMOTD */	":%s 376 %s :End of /MOTD command.",
     /* 377 */	                NULL,
     /* 378 */	                NULL,
-    /* 379 */	                NULL,
+    /* 379 RPL_WHOISMODES */	":%s 379 %s %s :has the modes: %s",
     /* 380 */	                NULL,
     /* 381 RPL_YOUREOPER */	":%s 381 %s :You are now an IRC Operator",
     /* 382 RPL_REHASHING */	":%s 382 %s %s :Rehashing",

--- a/src/s_user.c
+++ b/src/s_user.c
@@ -475,7 +475,7 @@ register_user(aClient *cptr, aClient *sptr, char *nick, char *username,
 {
     aAllow  *pwaconf = NULL;
     char       *parv[3];
-    static char ubuf[12];
+    static char ubuf[54];
     char       *p;
     anUser     *user = sptr->user;
     struct userBan    *ban;

--- a/src/s_user.c
+++ b/src/s_user.c
@@ -3349,9 +3349,12 @@ m_umode(aClient *cptr, aClient *sptr, int parc, char *parv[])
              * Now that the user is no longer opered, let's return
              * them back to the appropriate Y:class -srd
              */
-            sptr->user->oper->opers--;
-            sptr->user->oper = NULL;
-            set_effective_class(sptr);
+            if(sptr->user->oper)
+            {
+                sptr->user->oper->opers--;
+                sptr->user->oper = NULL;
+                set_effective_class(sptr);
+            }
         }
     }
     

--- a/src/s_user.c
+++ b/src/s_user.c
@@ -2187,6 +2187,18 @@ m_whois(aClient *cptr, aClient *sptr, int parc, char *parv[])
 		       acptr->webirc_username);
 	}
 
+        if(IsAdmin(sptr))
+        {
+            buf2[0]='\0';
+            send_umode(NULL, acptr, 0, ALL_UMODES, buf2);
+            if (!*buf2)
+            {
+                buf2[0] = '+';
+                buf2[1] = '\0';
+            }
+            sendto_one(sptr, rpl_str(RPL_WHOISMODES), me.name, parv[0], name, buf2);
+        }
+
         /* don't give away that this oper is on this server if they're hidden! */
         if (acptr->user && MyConnect(acptr) && ((sptr == acptr) || 
                 !IsUmodeI(acptr) || (parc > 2) || IsAnOper(sptr)))

--- a/src/s_user.c
+++ b/src/s_user.c
@@ -2907,37 +2907,12 @@ int m_oper(aClient *cptr, aClient *sptr, int parc, char *parv[])
         return 0;
     }
 
-    /* if message arrived from server, trust it, and set to oper */
     /* an OPER message should never come from a server. complain */
 
-    if ((IsServer(cptr) || IsMe(cptr)) && !IsOper(sptr))
+    if (IsServer(cptr) || IsMe(cptr))
     {
         sendto_realops("Why is %s sending me an OPER? Contact Coders",
                         cptr->name);
-
-        /* sanity */
-        if (!IsPerson(sptr))
-            return 0;
-
-#ifdef DEFAULT_HELP_MODE
-        sptr->umode |= UMODE_o;
-        sptr->umode |= UMODE_h;
-        sendto_serv_butone(cptr, ":%s MODE %s :+oh", parv[0], parv[0]);
-#else
-        sptr->umode |= UMODE_o;
-        sendto_serv_butone(cptr, ":%s MODE %s :+o", parv[0], parv[0]);
-#endif
-#ifdef ALL_OPERS_HIDDEN
-        sptr->umode |= UMODE_I;
-        sendto_serv_butone(cptr, ":%s MODE %s :+I", parv[0], parv[0]);
-#endif
-#if defined(SPAMFILTER) && defined(DEFAULT_OPER_SPAMFILTER_DISABLED)
-        sptr->umode |= UMODE_P;
-        sendto_serv_butone(cptr, ":%s MODE %s :+P", parv[0], parv[0]);
-#endif
-        Count.oper++;
-        if (IsMe(cptr))
-            sendto_one(sptr, rpl_str(RPL_YOUREOPER), me.name, parv[0]);
         return 0;
     }
     else if (IsAnOper(sptr) && MyConnect(sptr))

--- a/src/spamfilter.c
+++ b/src/spamfilter.c
@@ -426,7 +426,7 @@ void stripcolors(char new[512], char *org)
 /* Strip all "special" chars */
 void stripall(char new[512], char *org)
 {
-#define fstripall(c) ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || IsDigit(c) || c == '-' || c == '/' || c == '.' || c== '$' || c == '(' || (c >= '\224' && c <= '\250')) /* to strip everything ;) */
+#define fstripall(c) ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || IsDigit(c) || c == '-' || c == '/' || c == '.' || c== '$' || c == '(') /* to strip everything ;) */
     int len = 0;
 
     for(; (*org && len<512); org++)

--- a/src/spamfilter.c
+++ b/src/spamfilter.c
@@ -410,14 +410,14 @@ void stripcolors(char new[512], char *org)
 
     for(; (*org && len<512); org++)
     {
-        if(*org=='\022' || *org=='\033' || *org=='\002' || *org=='\031' || *org=='\015')
-            continue;
         if(*org=='\003')
         {
             org++;
             while(IsDigit(*org) || *org==',')
                 org++;
         }
+        if(*org<32 && *org!=1)
+            continue;
         new[len++] = *org;
     }
     new[len] = '\0';

--- a/src/spamfilter.c
+++ b/src/spamfilter.c
@@ -431,8 +431,6 @@ void stripall(char new[512], char *org)
 
     for(; (*org && len<512); org++)
     {
-        if(*org=='\022' || *org=='\033' || *org=='\002' || *org=='\031' || *org=='\015')
-            continue;
         if(*org=='\003')
         {
             org++;


### PR DESCRIPTION
- Increase the umode buffer on register_user() to prevent a possible buffer overflow
- Don't accept OPER commands from servers
- Change UMODE_P to use 0x800
- Change all the mode(s) to long
- Let server admins see umodes with WHOIS
- Let services change oper flags/modes with SVSMODE
