### PR TITLE
spamfilter fixes

### DIFF
--- a/include/spamfilter.h
+++ b/include/spamfilter.h
@@ -25,7 +25,7 @@ extern int save_spamfilter();
 extern void stripcolors(char new[512], char *org);
 extern void stripall(char new[512], char *org);
 extern int check_sf(aClient *cptr, char *text, char *caction, int action, char *target);
-extern struct spam_filter *new_sf(char *text, long flags, char *reason);
+extern struct spam_filter *new_sf(char *text, long flags, char *reason, char *target);
 extern void spamfilter_sendserver(aClient *acptr);
 
 #define SF_FLAG_NONE      000000

--- a/src/m_stats.c
+++ b/src/m_stats.c
@@ -52,6 +52,7 @@ extern void report_fds(aClient *);
 extern char *oflagtotext(int oflags); /* For stats o */
 extern char *cflagtotext(int cflags, int uflags); /* For stats c */
 extern char *iflagtotext(int iflags); /* For stats i */
+extern int report_spamfilters(aClient *cptr, aClient *sptr, int parc, char *parv[]); /* For stats S */
 
 /* internal function defines */
 
@@ -843,6 +844,12 @@ int m_stats(aClient *cptr, aClient *sptr, int parc, char *parv[])
             break;
 
         case 'S':
+            if (IsAnOper(sptr))
+                report_spamfilters(cptr, sptr, parc, parv);
+            else
+                sendto_one(sptr, err_str(ERR_NOPRIVILEGES), me.name,  parv[0]);
+            break;
+
         case 's':
             if (IsAnOper(sptr))
                 list_scache(cptr, sptr, parc, parv);

--- a/src/s_err.c
+++ b/src/s_err.c
@@ -268,7 +268,7 @@ static char *replies[] =
     /* 242 RPL_STATSUPTIME */	":%s 242 %s :Server Up %d days, %d:%02d:%02d",
     /* 243 RPL_STATSOLINE */	":%s 243 %s %s %s * %s %s %s",
     /* 244 RPL_STATSHLINE */	NULL,
-    /* 245 RPL_STATSSLINE */	":%s 245 %s %s %s %ld %s :%s",
+    /* 245 RPL_STATSSLINE */	":%s 245 %s %s %s %ld %s %lu :%s",
     /* 246 RPL_STATSXLINE */	":%s 246 %s %s %s * %s %d %d",
     /* 247 */	                NULL,		/* Undernet's STATSGLINE */
     /* 248 */	                NULL,		/* Undernet's STATSULINE */

--- a/src/s_err.c
+++ b/src/s_err.c
@@ -268,7 +268,7 @@ static char *replies[] =
     /* 242 RPL_STATSUPTIME */	":%s 242 %s :Server Up %d days, %d:%02d:%02d",
     /* 243 RPL_STATSOLINE */	":%s 243 %s %s %s * %s %s %s",
     /* 244 RPL_STATSHLINE */	NULL,
-    /* 245 RPL_STATSSLINE */	NULL,
+    /* 245 RPL_STATSSLINE */	":%s 245 %s %s %s %ld %s :%s",
     /* 246 RPL_STATSXLINE */	":%s 246 %s %s %s * %s %d %d",
     /* 247 */	                NULL,		/* Undernet's STATSGLINE */
     /* 248 */	                NULL,		/* Undernet's STATSULINE */

--- a/src/s_user.c
+++ b/src/s_user.c
@@ -1862,7 +1862,7 @@ m_message(aClient *cptr, aClient *sptr, int parc, char *parv[], int notice)
 #endif
 
 #ifdef SPAMFILTER
-            if(!IsUmodeP(acptr) && check_sf(sptr, parv[2], notice?"notice":"msg", notice?SF_CMD_NOTICE:SF_CMD_PRIVMSG, acptr->name))
+            if(!IsUmodeP(acptr) && sptr!=acptr && check_sf(sptr, parv[2], notice?"notice":"msg", notice?SF_CMD_NOTICE:SF_CMD_PRIVMSG, acptr->name))
                 return FLUSH_BUFFER;
 #endif
         }

--- a/src/spamfilter.c
+++ b/src/spamfilter.c
@@ -356,7 +356,7 @@ struct spam_filter *new_sf(char *text, long flags, char *reason, char *target)
             while(reason[len]!=']' && reason[len]!='\0')
                 len++;
         }
-        if(len > 1)
+        if(len > 1 && reason[len]==']')
         {
             p->id = MyMalloc(len);
             strncpy(p->id, &reason[1], len - 1);

--- a/src/spamfilter.c
+++ b/src/spamfilter.c
@@ -152,6 +152,7 @@ int m_spamops(aClient *cptr, aClient *sptr, int parc, char *parv[])
 
 /* check_sf - checks if a text matches a spamfilter pattern
               Returns: 1 = User message has been blocked.
+                       2 = User has been killed and the message has been blocked.
                        0 = User message was not blocked (but it doesn't mean we didn't have a non-block match).
  */
 int check_sf(aClient *cptr, char *text, char *caction, int action, char *target)

--- a/src/spamfilter.c
+++ b/src/spamfilter.c
@@ -490,7 +490,7 @@ void stripcolors(char new[512], char *org)
             while(IsDigit(*org) || *org==',')
                 org++;
         }
-        if(*org<32 && *org!=1)
+        if(*org<32)
             continue;
         new[len++] = *org;
     }

--- a/src/spamfilter.c
+++ b/src/spamfilter.c
@@ -460,6 +460,19 @@ int m_sf(aClient *cptr, aClient *sptr, int parc, char *parv[])
     return 0;
 }
 
+/* report_spamfilters - send /stats S (spamfilter list) output to opers */
+int report_spamfilters(aClient *cptr, aClient *sptr, int parc, char *parv[])
+{
+    struct spam_filter *sf = spam_filters;
+
+    for(; sf; sf = sf->next)
+    {
+        sendto_one(sptr, rpl_str(RPL_STATSSLINE), me.name,
+                   sptr->name, "S", sf->text, sf->flags,
+                   sf->target?sf->target:"<NONE>", sf->reason);
+    }
+}
+
 /* Strip colors and other control codes from a text */
 void stripcolors(char new[512], char *org)
 {


### PR DESCRIPTION
1. Don't check spamfilter if a user messages/notices themselves 
2. Add support for spamfilter id and use it on warnings when possible
3. Cosmetic comment fix
4. Add target support to spamfilter
5. spamfilter ids must end with a "]"
6. Let opers use STATS S to see the spamfilter list
7. Add counter for spamfitler matches