### PR TITLE
Add NO_UTF8 xflag (XCF)

### DIFF
--- a/include/spamfilter.h
+++ b/include/spamfilter.h
@@ -25,7 +25,7 @@ extern int save_spamfilter();
 extern void stripcolors(char new[512], char *org);
 extern void stripall(char new[512], char *org);
 extern int check_sf(aClient *cptr, char *text, char *caction, int action, char *target);
-extern struct spam_filter *new_sf(char *text, long flags, char *reason);
+extern struct spam_filter *new_sf(char *text, long flags, char *reason, char *target);
 extern void spamfilter_sendserver(aClient *acptr);
 
 #define SF_FLAG_NONE      000000

--- a/include/struct.h
+++ b/include/struct.h
@@ -1366,6 +1366,7 @@ struct Channel
 #define XFLAG_OPER_VERBOSE      0x1000
 #define XFLAG_SJR               0x2000 /* Services join request */
 #define XFLAG_NO_NICK_CHANGE    0x4000
+#define XFLAG_NO_UTF8           0x8000
 
 struct FlagList
 {

--- a/src/m_services.c
+++ b/src/m_services.c
@@ -827,6 +827,7 @@ struct FlagList xflags_list[] =
   { "EXEMPT_INVITES",    XFLAG_EXEMPT_INVITES    },
   { "HIDE_MODE_LISTS",   XFLAG_HIDE_MODE_LISTS   },
   { "NO_NICK_CHANGE",    XFLAG_NO_NICK_CHANGE    },
+  { "NO_UTF8",           XFLAG_NO_UTF8           },
   { "SJR",               XFLAG_SJR               },
   { "USER_VERBOSE",      XFLAG_USER_VERBOSE      },
   { "OPER_VERBOSE",      XFLAG_OPER_VERBOSE      },

--- a/src/s_user.c
+++ b/src/s_user.c
@@ -1862,7 +1862,7 @@ m_message(aClient *cptr, aClient *sptr, int parc, char *parv[], int notice)
 #endif
 
 #ifdef SPAMFILTER
-            if(!IsUmodeP(acptr) && check_sf(sptr, parv[2], notice?"notice":"msg", notice?SF_CMD_NOTICE:SF_CMD_PRIVMSG, acptr->name))
+            if(!IsUmodeP(acptr) && sptr!=acptr && check_sf(sptr, parv[2], notice?"notice":"msg", notice?SF_CMD_NOTICE:SF_CMD_PRIVMSG, acptr->name))
                 return FLUSH_BUFFER;
 #endif
         }

--- a/src/s_user.c
+++ b/src/s_user.c
@@ -368,6 +368,23 @@ canonize(char *buffer)
     return cbuf;
 }
 
+/* msg_has_utf8 - check if a message has high ASCII code characters.
+                  It doesn't have to be UTF8 really, Hebrew and Arabic
+                  characters will match as well... -Kobi_S.
+ */
+int msg_has_utf8(char *text)
+{
+    if(text == NULL) return 0;
+
+    while(*text)
+    {
+        if((unsigned char)*text > 127 && *text!='<' && *text!='>') return 1;
+        text++;
+    }
+
+    return 0;
+}
+
 #if (RIDICULOUS_PARANOIA_LEVEL>=1)
 static int
 check_oper_can_mask(aClient *sptr, char *name, char *password, char **onick)
@@ -1656,6 +1673,17 @@ m_message(aClient *cptr, aClient *sptr, int parc, char *parv[], int notice)
                         verbose_to_relaychan(sptr, chptr, "notice", parv[2]);
                     if(chptr->xflags & XFLAG_OPER_VERBOSE)
                         verbose_to_opers(sptr, chptr, "notice", parv[2]);
+                    continue;
+                }
+
+                if ((chptr->xflags & XFLAG_NO_UTF8) && msg_has_utf8(parv[2]) && !is_xflags_exempted(sptr,chptr))
+                {
+                    if (ismine && !notice)
+                        sendto_one(sptr, err_str(ERR_CANNOTSENDTOCHAN), me.name, parv[0], target);
+                    if(chptr->xflags & XFLAG_USER_VERBOSE)
+                        verbose_to_relaychan(sptr, chptr, notice?"utf8-notice":"utf8-message", parv[2]);
+                    if(chptr->xflags & XFLAG_OPER_VERBOSE)
+                        verbose_to_opers(sptr, chptr, notice?"utf8-notice":"utf8-message", parv[2]);
                     continue;
                 }
 

--- a/src/spamfilter.c
+++ b/src/spamfilter.c
@@ -152,6 +152,7 @@ int m_spamops(aClient *cptr, aClient *sptr, int parc, char *parv[])
 
 /* check_sf - checks if a text matches a spamfilter pattern
               Returns: 1 = User message has been blocked.
+                       2 = User has been killed and the message has been blocked.
                        0 = User message was not blocked (but it doesn't mean we didn't have a non-block match).
  */
 int check_sf(aClient *cptr, char *text, char *caction, int action, char *target)


### PR DESCRIPTION
When enabled, messages that contain high ASCII codes will be blocked.
It doesn't have to be UTF8 really, Hebrew and Arabic characters will be blocked as well.