### PR TITLE
Let's try to send the sendq list on exit_client()

### DIFF
--- a/src/s_misc.c
+++ b/src/s_misc.c
@@ -660,6 +660,7 @@ exit_client(aClient *cptr, aClient *sptr, aClient *from, char *comment)
                 sendto_one(sptr, "ERROR :Closing Link: %s (%s)",
                            IsPerson(sptr) ? sptr->sockhost : "0.0.0.0", 
                            comment);
+            send_queued(sptr); /* Attempt to send the sendq list (with the error message) as fast as we can -Kobi. */
         }
         /*
          * * Currently only server connections can have * depending


### PR DESCRIPTION
Right now, when users are killed/klined/akilled, they don't always get the kill message and are just getting disconnected with no message at all.
This will (try to) send the sendq list with the error message right away.

Note that this should *NOT* be included in Bahamut 2.1.2.

Kobi.
