### PR TITLE
Optimization & more sanity checks

### DIFF
--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -499,7 +499,7 @@ oper {
 #        f  Can use umode +f (see flood notices)
 #        W  Can use umode +b (CHATOPS)
 #        d  Can use umode +d (debug)
-#        y  Can use umode +y (spy)
+#        y  Can use umode +y (see /stats, /info, /admin, /trace and /motd requests)
 # 
 #     D  Can use DIE
 #     R  Can use RESTART

--- a/src/channel.c
+++ b/src/channel.c
@@ -3781,7 +3781,7 @@ void send_topic_burst(aClient *cptr)
                 sendto_one(cptr, ":%s SVSXCF %s JOIN_CONNECT_TIME:%d TALK_CONNECT_TIME:%d TALK_JOIN_TIME:%d", me.name, chptr->chname, chptr->join_connect_time, chptr->talk_connect_time, chptr->talk_join_time);
                 for(xflag = xflags_list; xflag->option; xflag++)
                 {
-                    sendto_one(cptr, ":%s SVSXCF %s:%d", me.name, xflag->option, (chptr->xflags & xflag->flag)?1:0);
+                    sendto_one(cptr, ":%s SVSXCF %s %s:%d", me.name, chptr->chname, xflag->option, (chptr->xflags & xflag->flag)?1:0);
                 }
                 if(chptr->greetmsg && (chptr->max_bans != MAXBANS))
                     sendto_one(cptr, ":%s SVSXCF %s MAX_BANS:%d GREETMSG :%s", me.name, chptr->chname, chptr->max_bans, chptr->greetmsg);

--- a/src/send.c
+++ b/src/send.c
@@ -594,7 +594,7 @@ void sendto_channel_butone(aClient *one, aClient *from, aChannel *chptr,
         if (acptr->from == one)
             continue; /* ...was the one I should skip */
 
-        if((confopts & FLAGS_SERVHUB) && IsULine(acptr) && (acptr->uplink->serv->uflags & ULF_NOCHANMSG))
+        if((confopts & FLAGS_SERVHUB) && IsULine(acptr) && (acptr->uplink->serv) && (acptr->uplink->serv->uflags & ULF_NOCHANMSG))
             continue; /* Don't send channel traffic to super servers */
 
         if (MyClient(acptr)) 
@@ -666,10 +666,12 @@ void sendto_channel_remote_butone(aClient *one, aClient *from, aChannel *chptr,
         if (acptr->from == one)
             continue; /* ...was the one I should skip */
 
-        if((confopts & FLAGS_SERVHUB) && IsULine(acptr) && (acptr->uplink->serv->uflags & ULF_NOCHANMSG))
+        if((confopts & FLAGS_SERVHUB) && IsULine(acptr) && (acptr->uplink->serv) && (acptr->uplink->serv->uflags & ULF_NOCHANMSG))
             continue; /* Don't send channel traffic to super servers */
 
-        i = acptr->from->fd;
+        if(acptr->fd == -2)
+            continue;
+
         if (!MyClient(acptr)) 
         {
             /*
@@ -686,6 +688,7 @@ void sendto_channel_remote_butone(aClient *one, aClient *from, aChannel *chptr,
             if(check_fake_direction(from, acptr))
                     continue;
             
+            i = acptr->from->fd;
             if (sentalong[i] != sent_serial) 
             {
                 send_message(acptr, remotebuf, didremote, share_buf);
@@ -2112,7 +2115,7 @@ void sendto_channelflags_butone(aClient *one, aClient *from, aChannel *chptr,
         if (acptr->from == one || !(cm->flags & flags))
             continue;
 
-        if((confopts & FLAGS_SERVHUB) && IsULine(acptr) && (acptr->uplink->serv->uflags & ULF_NOCHANMSG))
+        if((confopts & FLAGS_SERVHUB) && IsULine(acptr) && (acptr->uplink->serv) && (acptr->uplink->serv->uflags & ULF_NOCHANMSG))
             continue; /* Don't send channel traffic to super servers */
 
         if (MyConnect(acptr))

--- a/src/send.c
+++ b/src/send.c
@@ -597,7 +597,6 @@ void sendto_channel_butone(aClient *one, aClient *from, aChannel *chptr,
         if((confopts & FLAGS_SERVHUB) && IsULine(acptr) && (acptr->uplink->serv->uflags & ULF_NOCHANMSG))
             continue; /* Don't send channel traffic to super servers */
 
-        i = acptr->from->fd;
         if (MyClient(acptr)) 
         {
             if(!didlocal)
@@ -610,7 +609,6 @@ void sendto_channel_butone(aClient *one, aClient *from, aChannel *chptr,
                     continue;
             
             send_message(acptr, sendbuf, didlocal, share_bufs[0]);
-            sentalong[i] = sent_serial;
         }
         else 
         {
@@ -628,6 +626,7 @@ void sendto_channel_butone(aClient *one, aClient *from, aChannel *chptr,
             if(check_fake_direction(from, acptr))
                     continue;
             
+            i = acptr->from->fd;
             if (sentalong[i] != sent_serial) 
             {
                 send_message(acptr, remotebuf, didremote, share_bufs[1]);
@@ -1047,13 +1046,13 @@ void sendto_channel_butlocal(aClient *one, aClient *from, aChannel *chptr,
         acptr = cm->cptr;
         if (acptr->from == one)
             continue;           /* ...was the one I should skip */
-        i = acptr->from->fd;
         if (!MyFludConnect(acptr)) 
         {
             /*
              * Now check whether a message has been sent to this remote
              * link already
              */
+            i = acptr->from->fd;
             if (sentalong[i] != sent_serial) 
             {
                 vsendto_prefix_one(acptr, from, pattern, vl);


### PR DESCRIPTION
1. Optimize sendto_channel_butone() and sendto_channel_butlocal() functions.
There is no point to set sentalong for clients if we're not going to check it later (and we shouldn't anyway).
2. Only set i = acptr->from->fd when we need to.
3. A few more sanity checks to be on the safe side.

-Kobi.