### PR TITLE
A few fixes for Bahamut 2.1.4

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -1986,11 +1986,11 @@ static int set_mode(aClient *cptr, aClient *sptr, aChannel *chptr,
                 if((chptr->xflags & XFLAG_HIDE_MODE_LISTS) && !IsAnOper(sptr) && !is_chan_op(sptr,chptr))
                 {
                     if(chptr->xflags & XFLAG_USER_VERBOSE)
-                        verbose_to_relaychan(cptr, chptr, "mode(+I)", NULL);
+                        verbose_to_relaychan(sptr, chptr, "mode(+I)", NULL);
                     if(chptr->xflags & XFLAG_OPER_VERBOSE)
-                        verbose_to_opers(cptr, chptr, "mode(+I)", NULL);
-                    sendto_one(cptr, rpl_str(RPL_ENDOFINVITELIST), me.name,
-                               cptr->name, chptr->chname);
+                        verbose_to_opers(sptr, chptr, "mode(+I)", NULL);
+                    sendto_one(sptr, rpl_str(RPL_ENDOFINVITELIST), me.name,
+                               sptr->name, chptr->chname);
                     anylistsent = 1;
                     break;
                 }
@@ -2069,11 +2069,11 @@ static int set_mode(aClient *cptr, aClient *sptr, aChannel *chptr,
                 if((chptr->xflags & XFLAG_HIDE_MODE_LISTS) && !IsAnOper(sptr) && !is_chan_op(sptr,chptr))
                 {
                     if(chptr->xflags & XFLAG_USER_VERBOSE)
-                        verbose_to_relaychan(cptr, chptr, "mode(+e)", NULL);
+                        verbose_to_relaychan(sptr, chptr, "mode(+e)", NULL);
                     if(chptr->xflags & XFLAG_OPER_VERBOSE)
-                        verbose_to_opers(cptr, chptr, "mode(+e)", NULL);
-                    sendto_one(cptr, rpl_str(RPL_ENDOFEXEMPTLIST), me.name,
-                               cptr->name, chptr->chname);
+                        verbose_to_opers(sptr, chptr, "mode(+e)", NULL);
+                    sendto_one(sptr, rpl_str(RPL_ENDOFEXEMPTLIST), me.name,
+                               sptr->name, chptr->chname);
                     anylistsent = 1;
                     break;
                 }
@@ -2151,11 +2151,11 @@ static int set_mode(aClient *cptr, aClient *sptr, aChannel *chptr,
                 if((chptr->xflags & XFLAG_HIDE_MODE_LISTS) && !IsAnOper(sptr) && !is_chan_op(sptr,chptr))
                 {
                     if(chptr->xflags & XFLAG_USER_VERBOSE)
-                        verbose_to_relaychan(cptr, chptr, "mode(+b)", NULL);
+                        verbose_to_relaychan(sptr, chptr, "mode(+b)", NULL);
                     if(chptr->xflags & XFLAG_OPER_VERBOSE)
-                        verbose_to_opers(cptr, chptr, "mode(+b)", NULL);
-                    sendto_one(cptr, rpl_str(RPL_ENDOFBANLIST), me.name,
-                               cptr->name, chptr->chname);
+                        verbose_to_opers(sptr, chptr, "mode(+b)", NULL);
+                    sendto_one(sptr, rpl_str(RPL_ENDOFBANLIST), me.name,
+                               sptr->name, chptr->chname);
                     anylistsent = 1;
                     break;
                 }
@@ -3561,9 +3561,9 @@ int m_part(aClient *cptr, aClient *sptr, int parc, char *parv[])
         if (parc < 3 || can_send(sptr,chptr,reason) || IsSquelch(sptr) || ((chptr->xflags & XFLAG_NO_PART_MSG) && !is_xflags_exempted(sptr,chptr)))
         {
             if(reason && *reason && (chptr->xflags & XFLAG_USER_VERBOSE))
-                verbose_to_relaychan(cptr, chptr, "part_msg", reason);
+                verbose_to_relaychan(sptr, chptr, "part_msg", reason);
             if(reason && *reason && (chptr->xflags & XFLAG_OPER_VERBOSE))
-                verbose_to_opers(cptr, chptr, "part_msg", reason);
+                verbose_to_opers(sptr, chptr, "part_msg", reason);
             sendto_serv_butone(cptr, PartFmt, parv[0], name);
             sendto_channel_butserv(chptr, sptr, PartFmt, parv[0], name);
         }

--- a/src/channel.c
+++ b/src/channel.c
@@ -3781,6 +3781,7 @@ void send_topic_burst(aClient *cptr)
                 sendto_one(cptr, ":%s SVSXCF %s JOIN_CONNECT_TIME:%d TALK_CONNECT_TIME:%d TALK_JOIN_TIME:%d", me.name, chptr->chname, chptr->join_connect_time, chptr->talk_connect_time, chptr->talk_join_time);
                 for(xflag = xflags_list; xflag->option; xflag++)
                 {
+                    if(!strcmp(xflag->option,"USER_VERBOSE") || !strcmp(xflag->option,"OPER_VERBOSE")) continue;
                     sendto_one(cptr, ":%s SVSXCF %s %s:%d", me.name, chptr->chname, xflag->option, (chptr->xflags & xflag->flag)?1:0);
                 }
                 if(chptr->greetmsg && (chptr->max_bans != MAXBANS))

--- a/src/m_services.c
+++ b/src/m_services.c
@@ -830,7 +830,9 @@ struct FlagList xflags_list[] =
   { "NO_UTF8",           XFLAG_NO_UTF8           },
   { "SJR",               XFLAG_SJR               },
   { "USER_VERBOSE",      XFLAG_USER_VERBOSE      },
+  { "USER_VERBOSEV2",    XFLAG_USER_VERBOSE      },
   { "OPER_VERBOSE",      XFLAG_OPER_VERBOSE      },
+  { "OPER_VERBOSEV2",    XFLAG_OPER_VERBOSE      },
   { NULL,                0                       }
 };
 

--- a/src/m_webirc.c
+++ b/src/m_webirc.c
@@ -112,7 +112,10 @@ int m_webirc(aClient *cptr, aClient *sptr, int parc, char *parv[])
     cptr->webirc_ip = MyMalloc(strlen(cptr->sockhost) + 1);
     strcpy(cptr->webirc_ip, cptr->sockhost);
 
-    get_sockhost(cptr, parv[3]);
+    if(strlen(parv[3]) > HOSTLEN)
+        get_sockhost(cptr, parv[4]); /* IP (because host is too long) */
+    else
+        get_sockhost(cptr, parv[3]); /* host */
     cptr->hostp = NULL;
 
     /*

--- a/src/m_webirc.c
+++ b/src/m_webirc.c
@@ -100,7 +100,7 @@ int m_webirc(aClient *cptr, aClient *sptr, int parc, char *parv[])
     }
 
     /* Don't allow WEBIRC to use 0.0.0.*, 127.0.0.* or Staff_Address -Kobi_S. */
-    if(!strncmp(parv[3],"0.0.0.",6) || !strncmp(parv[3],"127.0.0.",8) || !strcasecmp(parv[3],Staff_Address) || !strcasecmp(parv[3],DEFAULT_STAFF_ADDRESS) || !strncmp(parv[4],"0.0.0.",6) || !strncmp(parv[4],"127.",4))
+    if(!strncmp(parv[3],"0.0.0.",6) || !strncmp(parv[3],"127.0.0.",8) || !strcasecmp(parv[3],Staff_Address) || !strcasecmp(parv[3],DEFAULT_STAFF_ADDRESS) || !strchr(parv[3],'.') || !strncmp(parv[4],"0.0.0.",6) || !strncmp(parv[4],"127.",4))
     {
         sendto_realops_lev(SPY_LEV, "WEBIRC: %s@%s tried to spoof %s (%s)",
                            oldusername, sptr->sockhost,

--- a/src/m_webirc.c
+++ b/src/m_webirc.c
@@ -100,7 +100,7 @@ int m_webirc(aClient *cptr, aClient *sptr, int parc, char *parv[])
     }
 
     /* Don't allow WEBIRC to use 0.0.0.*, 127.0.0.* or Staff_Address -Kobi_S. */
-    if(!strncmp(parv[3],"0.0.0.",6) || !strncmp(parv[3],"127.0.0.",8) || !strcasecmp(parv[3],Staff_Address) || !strncmp(parv[4],"0.0.0.",6) || !strncmp(parv[4],"127.",4))
+    if(!strncmp(parv[3],"0.0.0.",6) || !strncmp(parv[3],"127.0.0.",8) || !strcasecmp(parv[3],Staff_Address) || !strcasecmp(parv[3],DEFAULT_STAFF_ADDRESS) || !strncmp(parv[4],"0.0.0.",6) || !strncmp(parv[4],"127.",4))
     {
         sendto_realops_lev(SPY_LEV, "WEBIRC: %s@%s tried to spoof %s (%s)",
                            oldusername, sptr->sockhost,

--- a/src/m_webirc.c
+++ b/src/m_webirc.c
@@ -100,7 +100,7 @@ int m_webirc(aClient *cptr, aClient *sptr, int parc, char *parv[])
     }
 
     /* Don't allow WEBIRC to use 0.0.0.*, 127.0.0.* or Staff_Address -Kobi_S. */
-    if(!strncmp(parv[3],"0.0.0.",6) || !strncmp(parv[3],"127.0.0.",8) || !strcasecmp(parv[3],Staff_Address) || !strcasecmp(parv[3],DEFAULT_STAFF_ADDRESS) || !strchr(parv[3],'.') || !strncmp(parv[4],"0.0.0.",6) || !strncmp(parv[4],"127.",4))
+    if(!strncmp(parv[3],"0.0.0.",6) || !strncmp(parv[3],"127.0.0.",8) || !strcasecmp(parv[3],Staff_Address) || !strcasecmp(parv[3],DEFAULT_STAFF_ADDRESS) || (!strchr(parv[3],'.') && !strchr(parv[3],':')) || !strncmp(parv[4],"0.0.0.",6) || !strncmp(parv[4],"127.",4))
     {
         sendto_realops_lev(SPY_LEV, "WEBIRC: %s@%s tried to spoof %s (%s)",
                            oldusername, sptr->sockhost,

--- a/src/m_webirc.c
+++ b/src/m_webirc.c
@@ -99,6 +99,16 @@ int m_webirc(aClient *cptr, aClient *sptr, int parc, char *parv[])
 	return 0;
     }
 
+    /* Don't allow WEBIRC to use 0.0.0.*, 127.0.0.* or Staff_Address -Kobi_S. */
+    if(!strncmp(parv[3],"0.0.0.",6) || !strncmp(parv[3],"127.0.0.",8) || !strcasecmp(parv[3],Staff_Address) || !strncmp(parv[4],"0.0.0.",6) || !strncmp(parv[4],"127.",4))
+    {
+        sendto_realops_lev(SPY_LEV, "WEBIRC: %s@%s tried to spoof %s (%s)",
+                           oldusername, sptr->sockhost,
+                           parv[3], parv[4]);
+	sendto_one(sptr, "NOTICE * :Invalid IP");
+	return 0;
+    }
+
     if (cptr->flags & FLAGS_GOTID)
     {
 	cptr->webirc_username = MyMalloc(strlen(cptr->username) + 1);

--- a/src/s_serv.c
+++ b/src/s_serv.c
@@ -3194,6 +3194,7 @@ m_check(aClient *cptr, aClient *sptr, int parc, char *parv[])
             sendto_one(sptr, "NOTICE %s :GREETMSG: %s", parv[0], chptr->greetmsg?chptr->greetmsg:"<NONE>");
             for(xflag = xflags_list; xflag->option; xflag++)
             {
+                if(!strcmp(xflag->option,"USER_VERBOSE") || !strcmp(xflag->option,"OPER_VERBOSE")) continue;
                 sendto_one(sptr, "NOTICE %s :%s: %s", parv[0], xflag->option, (chptr->xflags & xflag->flag)?"On":"Off");
             }
             sendto_one(sptr, "NOTICE %s :*** End of Check ***", parv[0]);


### PR DESCRIPTION
- typo fix (cptr --> sptr) that could lead to server crashes in some cases
- Duplicate USER_VERBOSE and OPER_VERBOSE xflags into USER_VERBOSEV2 and OPER_VERBOSEV2
  (this will make it easier for us to enable them on upgraded servers without affecting non-upgraded servers).
- Don't accept too long hostnames from WEBIRC
- Don't allow WEBIRC to use 0.0.0.*, 127.0.0.* or Staff_Address
- Don't allow WEBIRC to use DEFAULT_STAFF_ADDRESS either
- Make sure the host on WEBIRC will have at least one dot