### PR TITLE
Let's check for local openssl installation first & rpath it too

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -427,7 +427,7 @@ if test "X$cf_enable_openssl" != "Xno" ; then
      cf_openssl_basedir="${cf_enable_openssl}"
   else
     dnl Do the auto-probe here.  Check some common directory paths.
-    for dirs in /usr/local/ssl /usr/pkg /usr/local /usr/lib /usr/lib/ssl\
+    for dirs in $HOME/openssl /usr/local/ssl /usr/pkg /usr/local /usr/lib /usr/lib/ssl\
                 /opt /opt/openssl /usr/local/openssl ; do
       if test -f "${dirs}/include/openssl/opensslv.h" ; then
         cf_openssl_basedir="${dirs}"
@@ -441,6 +441,9 @@ if test "X$cf_enable_openssl" != "Xno" ; then
     if test -f "${cf_openssl_basedir}/include/openssl/opensslv.h" ; then
       SSL_INCLUDES="-I${cf_openssl_basedir}/include"
       SSL_LDFLAGS="-L${cf_openssl_basedir}/lib"
+      if test "$cf_openssl_basedir" = "$HOME/openssl"; then
+        SSL_LDFLAGS="-L${cf_openssl_basedir}/lib -Wl,-rpath,${cf_openssl_basedir}/lib"
+      fi
     else
       dnl OpenSSL wasn't found in the directory specified.  Naughty
       dnl administrator...


### PR DESCRIPTION
1. If $HOME/openssl exists - we'll use it.
2. We'll add -Wl,-rpath,/path/to/openssl/lib to SSL_LDFLAGS so our binaries will be statically linked to the local openssl libs.

-Kobi.