### PR TITLE
SSL Fixes

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -427,7 +427,7 @@ if test "X$cf_enable_openssl" != "Xno" ; then
      cf_openssl_basedir="${cf_enable_openssl}"
   else
     dnl Do the auto-probe here.  Check some common directory paths.
-    for dirs in /usr/local/ssl /usr/pkg /usr/local /usr/lib /usr/lib/ssl\
+    for dirs in $HOME/openssl /usr/local/ssl /usr/pkg /usr/local /usr/lib /usr/lib/ssl\
                 /opt /opt/openssl /usr/local/openssl ; do
       if test -f "${dirs}/include/openssl/opensslv.h" ; then
         cf_openssl_basedir="${dirs}"
@@ -441,6 +441,9 @@ if test "X$cf_enable_openssl" != "Xno" ; then
     if test -f "${cf_openssl_basedir}/include/openssl/opensslv.h" ; then
       SSL_INCLUDES="-I${cf_openssl_basedir}/include"
       SSL_LDFLAGS="-L${cf_openssl_basedir}/lib"
+      if test "$cf_openssl_basedir" = "$HOME/openssl"; then
+        SSL_LDFLAGS="-L${cf_openssl_basedir}/lib -Wl,-rpath,${cf_openssl_basedir}/lib"
+      fi
     else
       dnl OpenSSL wasn't found in the directory specified.  Naughty
       dnl administrator...

--- a/src/s_bsd.c
+++ b/src/s_bsd.c
@@ -1245,6 +1245,8 @@ char *irc_get_sockerr(aClient *cptr)
             return "dbuf allocation error";
         case IRCERR_ZIP:
             return "compression general failure";
+        case IRCERR_SSL:
+            return "SSL error";
         default:
             return "Unknown error!";
     }

--- a/src/s_bsd.c
+++ b/src/s_bsd.c
@@ -1641,7 +1641,7 @@ void read_error_exit(aClient *cptr, int length, int err)
         }
     }
     
-    if (err)
+    if (err && !(err==IRCERR_SSL && length==-1 && errno==0))
         ircsprintf(errmsg, "Read error: %s", strerror(err));
     else
         ircsprintf(errmsg, "Client closed connection");

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -344,8 +344,11 @@ static int fatal_ssl_error(int ssl_error, int where, aClient *sptr)
 		username : "<unregistered>", sptr->sockhost,
 		(errno > 0) ? " " : " no ", errstr, ssl_errstr);
 #ifdef USE_SYSLOG
-    syslog(LOG_ERR, "SSL error in %s: %s [%s]", ssl_func, errstr,
-	    ssl_errstr);
+    syslog(LOG_ERR, "SSL error in %s for %s!%s@%s: %s [%s]", ssl_func,
+            *sptr->name ? sptr->name : "<unknown>",
+            (sptr->user && sptr->user->username) ? sptr->user->
+            username : "<unregistered>", sptr->sockhost
+            errstr, ssl_errstr);
 #endif
 
     /* if we reply() something here, we might just trigger another

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -347,7 +347,7 @@ static int fatal_ssl_error(int ssl_error, int where, aClient *sptr)
     syslog(LOG_ERR, "SSL error in %s for %s!%s@%s: %s [%s]", ssl_func,
             *sptr->name ? sptr->name : "<unknown>",
             (sptr->user && sptr->user->username) ? sptr->user->
-            username : "<unregistered>", sptr->sockhost
+            username : "<unregistered>", sptr->sockhost,
             errstr, ssl_errstr);
 #endif
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -337,6 +337,15 @@ static int fatal_ssl_error(int ssl_error, int where, aClient *sptr)
 	    ssl_errstr = "Unknown OpenSSL error (huh?)";
     }
 
+    if((ssl_error==SSL_ERROR_SYSCALL || ssl_error==SSL_ERROR_ZERO_RETURN) && errtmp==0)
+    {
+        /* Client most likely just closed the connection... -Kobi_S. */
+        errno = 0; /* Not really an error */
+        sptr->sockerr = IRCERR_SSL;
+        sptr->flags |= FLAGS_DEADSOCKET;
+        return -1;
+    }
+
     sendto_realops_lev(DEBUG_LEV, "%s to "
 		"%s!%s@%s aborted with%serror (%s). [%s]", 
 		ssl_func, *sptr->name ? sptr->name : "<unknown>",


### PR DESCRIPTION
1. USE_SYSLOG: Include nick!user@host in SSL errors
2. Add IRCERR_SSL to irc_get_sockerr() function
3. Treat normal connection closes by SSL users as such (this fixes issue #71)

-Kobi.