### PR TITLE
Added MAX_MSG_TIME XFLAG

### DIFF
--- a/include/numeric.h
+++ b/include/numeric.h
@@ -237,7 +237,7 @@
 #define ERR_NONONREG         486
 #define ERR_MSGSERVICES      487
 #define ERR_NOSSL            488
-
+#define ERR_MAXMSGSENT       490
 #define ERR_NOOPERHOST       491
 
 #define ERR_NOSHAREDCHAN     493

--- a/include/struct.h
+++ b/include/struct.h
@@ -1198,6 +1198,8 @@ struct ChanLink
     aClient *cptr;
     int flags;
     time_t when;
+    int last_message_number;    /* Number of messages sent to channel within max_messages_time */
+    time_t last_message_time;   /* When last message was sent to channel. -Holbrook */
     unsigned int banserial;     /* used for bquiet cache */
 };
 
@@ -1271,6 +1273,8 @@ struct Channel
     int talk_join_time;         /* Number of seconds the user must be on the channel to be able to tlak on the channel */
     int max_bans;               /* Maximum number of bans ops can add (default: MAXBANS) */
     int max_invites;            /* Maximum number of invites ops can add (default: MAXINVITELIST) */
+    int max_messages;           /* Maximum number of messages can be sent within max_messages_time */
+    int max_messages_time;      /* Number of seconds for how many messages can be sent, e.g., 5:10, 5 messages in 10 seconds */
     char *greetmsg;             /* Special greeting message */
     int xflags;                 /* The eXtended channel flags */
 };

--- a/src/channel.c
+++ b/src/channel.c
@@ -1155,6 +1155,8 @@ void add_user_to_channel(aChannel *chptr, aClient *who, int flags)
         cm->next = chptr->members;
         cm->banserial = chptr->banserial;
         cm->when = NOW;
+        cm->last_message_number = 0;
+        cm->last_message_time = 0;
 
         chptr->members = cm;
         chptr->users++;
@@ -1242,6 +1244,17 @@ time_t get_user_jointime(aClient *cptr, aChannel *chptr)
     if (chptr)
         if ((cm = find_user_member(chptr->members, cptr)))
             return cm->when;
+
+    return 0;
+}
+
+time_t get_user_lastmsgtime(aClient *cptr, aChannel *chptr)
+{
+    chanMember   *cm;
+
+    if (chptr)
+        if ((cm = find_user_member(chptr->members, cptr)))
+            return cm->last_message_time;
 
     return 0;
 }
@@ -1366,6 +1379,20 @@ int can_send(aClient *cptr, aChannel *chptr, char *msg)
                 return (ERR_NEEDTOWAIT);
             if (chptr->talk_join_time && (cm->when + chptr->talk_join_time > NOW) && !is_xflags_exempted(cptr,chptr))
                 return (ERR_NEEDTOWAIT);
+            if (chptr->max_messages && chptr->max_messages_time && !is_xflags_exempted(cptr,chptr))
+            {
+                if ((NOW - cm->last_message_time) < chptr->max_messages_time)
+                {
+                    if (cm->last_message_number > chptr->max_messages)
+                        return (ERR_MAXMSGSENT);
+                    else
+                        cm->last_message_number++;
+                }
+                else
+                    cm->last_message_number = 1;
+
+                cm->last_message_time = NOW;
+            }
         }
     }
     

--- a/src/channel.c
+++ b/src/channel.c
@@ -3805,7 +3805,7 @@ void send_topic_burst(aClient *cptr)
             if(chptr->xflags & XFLAG_SET)
             {
                 /* Not very optimized but we'll survive... -Kobi. */
-                sendto_one(cptr, ":%s SVSXCF %s JOIN_CONNECT_TIME:%d TALK_CONNECT_TIME:%d TALK_JOIN_TIME:%d", me.name, chptr->chname, chptr->join_connect_time, chptr->talk_connect_time, chptr->talk_join_time);
+                sendto_one(cptr, ":%s SVSXCF %s JOIN_CONNECT_TIME:%d MAX_MSG_TIME:%d:%d TALK_CONNECT_TIME:%d TALK_JOIN_TIME:%d", me.name, chptr->chname, chptr->join_connect_time, chptr->max_messages, chptr->max_messages_time, chptr->talk_connect_time, chptr->talk_join_time);
                 for(xflag = xflags_list; xflag->option; xflag++)
                 {
                     if(!strcmp(xflag->option,"USER_VERBOSE") || !strcmp(xflag->option,"OPER_VERBOSE")) continue;

--- a/src/m_services.c
+++ b/src/m_services.c
@@ -936,6 +936,22 @@ int m_svsxcf(aClient *cptr, aClient *sptr, int parc, char *parv[])
             else if(!strcasecmp(opt,"TALK_JOIN_TIME")) { chptr->talk_join_time = atoi(value); chptr->xflags |= XFLAG_SET; }
             else if(!strcasecmp(opt,"MAX_BANS")) { chptr->max_bans = atoi(value); chptr->xflags |= XFLAG_SET; }
             else if(!strcasecmp(opt,"MAX_INVITES")) { chptr->max_invites = atoi(value); chptr->xflags |= XFLAG_SET; }
+            else if(!strcasecmp(opt,"MAX_MSG_TIME"))
+            {
+                char *mmt_value;
+                mmt_value = opt;
+
+                if ((mmt_value = strchr(value, ':')))
+                {
+                    *mmt_value = '\0';
+                    mmt_value++;
+
+                    chptr->max_messages = atoi(value);
+                    chptr->max_messages_time = atoi(mmt_value);
+                    chptr->xflags |= XFLAG_SET;
+                }
+            }
+
             else
             {
                 for(xflag = xflags_list; xflag->option; xflag++)

--- a/src/s_err.c
+++ b/src/s_err.c
@@ -556,7 +556,7 @@ static char *replies[] =
     /* 488 ERR_NOSSL */	        ":%s 488 %s :SSL Only channel (+S), You must connect "
                                 "using SSL to join this channel.",
     /* 489 */	                NULL,	/* In use by Undernet */
-    /* 490 */	                NULL,
+    /* 490 ERR_MAXMSGSENT */    ":%s 490 %s :You must wait %ld seconds before you can send another message to %s",
     /* 491 ERR_NOOPERHOST */	":%s 491 %s :No Oper block for your host",
     /* 492 */	                NULL,
     /* 493 ERR_NOSHAREDCHAN */	":%s 493 %s :You cannot message that person because you do not share a common channel with them.",

--- a/src/s_serv.c
+++ b/src/s_serv.c
@@ -3191,6 +3191,7 @@ m_check(aClient *cptr, aClient *sptr, int parc, char *parv[])
             sendto_one(sptr, "NOTICE %s :TALK_JOIN_TIME: %d", parv[0], chptr->talk_join_time);
             sendto_one(sptr, "NOTICE %s :MAX_BANS: %d", parv[0], chptr->max_bans);
             sendto_one(sptr, "NOTICE %s :MAX_INVITES: %d", parv[0], chptr->max_invites);
+            sendto_one(sptr, "NOTICE %s :MAX_MSG_TIME: %d:%d", parv[0], chptr->max_messages, chptr->max_messages_time);
             sendto_one(sptr, "NOTICE %s :GREETMSG: %s", parv[0], chptr->greetmsg?chptr->greetmsg:"<NONE>");
             for(xflag = xflags_list; xflag->option; xflag++)
             {

--- a/src/s_user.c
+++ b/src/s_user.c
@@ -61,6 +61,7 @@ extern int is_xflags_exempted(aClient *sptr, aChannel *chptr); /* for m_message(
 extern int verbose_to_relaychan(aClient *sptr, aChannel *chptr, char *cmd, char *reason); /* for m_message() */
 extern inline void verbose_to_opers(aClient *sptr, aChannel *chptr, char *cmd, char *reason); /* for m_message() */
 extern time_t get_user_jointime(aClient *cptr, aChannel *chptr); /* for send_msg_error() */
+extern time_t get_user_lastmsgtime(aClient *cptr, aChannel *chptr); /* also for send_msg_error() -Holbrook */
 extern int server_was_split;
 extern int svspanic;
 extern int svsnoop;
@@ -1535,6 +1536,9 @@ send_msg_error(aClient *sptr, char *parv[], char *nick, int ret, aChannel *chptr
         sendto_one(sptr, err_str(ERR_NEEDREGGEDNICK), me.name,
                    parv[0], nick, "speak in", aliastab[AII_NS].nick,
                    aliastab[AII_NS].server, NS_Register_URL);
+    else if(ret == ERR_MAXMSGSENT)
+        sendto_one(sptr, err_str(ERR_MAXMSGSENT), me.name,
+                   parv[0], (chptr->max_messages_time + get_user_lastmsgtime(sptr, chptr) - NOW + 1), chptr->chname);
     else
         sendto_one(sptr, err_str(ERR_CANNOTSENDTOCHAN), me.name,
                    parv[0], nick);


### PR DESCRIPTION
Added MAX_MSG_TIME XFLAG, sets a maximum amount of messages that can be sent to a channel in x seconds.