### PR TITLE
Spelling correction to rehash notification

### DIFF
--- a/src/s_serv.c
+++ b/src/s_serv.c
@@ -1814,7 +1814,7 @@ local_rehash(aClient *cptr, aClient *sptr, char *sender, char *option)
 		else
 			sendto_one(sptr, rpl_str(RPL_REHASHING), me.name, sender, configfile);
 
-		sendto_ops("%s is rehashing Server config file while whistline innocently", sender);
+		sendto_ops("%s is rehashing Server config file while whistling innocently", sender);
 
 #ifdef USE_SYSLOG
 		syslog(LOG_INFO, "REHASH from %s\n", get_client_name(sptr, FALSE));


### PR DESCRIPTION
On 10DEC2018, tau reported to #bahamut an erroneous spelling of the word "whistling" in the rehash notification:

[15:17.09] [tau] 20:16 !bifrost.ca.us.dal.net *** Notice -- tau is rehashing Server config file while whistline innocently
[15:17.12] [tau] shouldn't that be "
[15:17.18] [tau] "whistling"

This pull request corrects the typo. 