### PR TITLE
Change SVSUHM to support optional parameter to control umode +H

### DIFF
--- a/src/m_server.c
+++ b/src/m_server.c
@@ -36,6 +36,7 @@ extern void reset_sock_opts(int, int);
 extern void spamfilter_sendserver(aClient *acptr);
 extern int user_modes[];
 extern int uhm_type;
+extern int uhm_umodeh;
 
 /* internal functions */
 
@@ -266,7 +267,7 @@ do_server_estab(aClient *cptr)
 
     /* Send UHM (user host-masking) type */
     if(confopts & FLAGS_HUB)
-        sendto_one(cptr, "SVSUHM %d", uhm_type);
+        sendto_one(cptr, "SVSUHM %d %d", uhm_type, uhm_umodeh);
 
     /* send clone list */
     clones_send(cptr);

--- a/src/m_services.c
+++ b/src/m_services.c
@@ -45,6 +45,7 @@ extern void read_shortmotd(char *); /* defined in s_serv.c */
 int svspanic = 0; /* Services panic */
 int svsnoop = 0; /* Services disabled all o:lines (off by default) */
 int uhm_type = 0; /* User host-masking type (off by default) */
+int uhm_umodeh = 0; /* Let users set umode +H (off by default) */
 int services_jr = 0; /* Redirect join requests to services (disabled by default) */
 
 /*
@@ -795,6 +796,7 @@ int m_svstag(aClient *cptr, aClient *sptr, int parc, char *parv[])
  *   Define the running user host-masking type
  * parv[0] - sender
  * parv[1] - host-masking type (number)
+ * parv[2] - optional umode +H status (0=disabled,1=enabled with auto +H on connect,2=enabled with no auto +H)
  */
 int m_svsuhm(aClient *cptr, aClient *sptr, int parc, char *parv[])
 {
@@ -809,7 +811,12 @@ int m_svsuhm(aClient *cptr, aClient *sptr, int parc, char *parv[])
 
     uhm_type = atoi(parv[1]);
 
-    sendto_serv_butone(cptr, ":%s SVSUHM %s", sptr->name, parv[1]);
+    if(parc > 2)
+    {
+        uhm_umodeh = atoi(parv[2]);
+        sendto_serv_butone(cptr, ":%s SVSUHM %s %s", sptr->name, parv[1], parv[2]);
+    }
+    else sendto_serv_butone(cptr, ":%s SVSUHM %s", sptr->name, parv[1]);
 
     return 0;
 }

--- a/src/s_user.c
+++ b/src/s_user.c
@@ -65,6 +65,7 @@ extern int server_was_split;
 extern int svspanic;
 extern int svsnoop;
 extern int uhm_type;
+extern int uhm_umodeh;
 
 static char buf[BUFSIZE], buf2[BUFSIZE];
 int  user_modes[] =
@@ -2329,7 +2330,7 @@ do_user(char *nick, aClient *cptr, aClient *sptr, char *username, char *host,
 #endif
         strncpyzt(user->host, host, sizeof(user->host));
 #ifdef USER_HOSTMASKING
-        if(uhm_type > 0) sptr->umode |= UMODE_H;
+        if((uhm_type > 0) && (uhm_umodeh == 1)) sptr->umode |= UMODE_H;
         else sptr->umode &= ~UMODE_H;
 #endif
         user->server = me.name;
@@ -3323,7 +3324,7 @@ m_umode(aClient *cptr, aClient *sptr, int parc, char *parv[])
                 case 'S':
                     break; /* users can't set themselves +r,+x,+X or +S! */
                 case 'H':
-                    if ((uhm_type > 0) && (what == MODE_ADD))
+                    if ((uhm_type > 0) && (uhm_umodeh > 0) && (what == MODE_ADD))
                         sptr->umode |= UMODE_H;
                     else
                         sptr->umode &= ~UMODE_H;


### PR DESCRIPTION
0 = disabled (default)
1 = enabled with auto +H on connect (users can toggle umode +H/-H)
2 = enabled with no auto +H on connect (users can toggle umode +H/-H)

-Kobi.