### PR TITLE
Add half-ops support

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -875,6 +875,13 @@
 #define DEFAULT_OPER_SPAMFILTER_DISABLED
 #endif
 
+/*
+ * USE_HALFOPS is used to enable half-ops support
+ * If you are connected to the main DALnet network, you should
+ * have this enabled.
+ */
+#define USE_HALFOPS
+
 /* ------------------------- END CONFIGURATION SECTION -------------------- */
 #ifdef APOLLO
 #define RESTARTING_SYSTEMCALLS

--- a/include/config.h
+++ b/include/config.h
@@ -882,6 +882,11 @@
  */
 #define USE_HALFOPS
 
+/*
+ * Don't allow local clients to use +h/-h until all servers and services are upgraded.
+ */
+#define NO_LOCAL_CMODE_h
+
 /* ------------------------- END CONFIGURATION SECTION -------------------- */
 #ifdef APOLLO
 #define RESTARTING_SYSTEMCALLS

--- a/include/h.h
+++ b/include/h.h
@@ -106,6 +106,7 @@ extern void 	 del_invite(aClient *, aChannel *);
 extern void 	 send_user_joins(aClient *, aClient *);
 extern int  	 can_send(aClient *, aChannel *, char *);
 extern int   	 is_chan_op(aClient *, aChannel *);
+extern int       is_chan_halfop(aClient *, aChannel *);
 extern int   	 is_chan_opvoice(aClient *, aChannel *);
 extern int  	 has_voice(aClient *, aChannel *);
 extern int  	 count_channels(aClient *);

--- a/include/struct.h
+++ b/include/struct.h
@@ -1287,6 +1287,7 @@ struct Channel
 #define	CHFL_VOICE      0x0002	/* the power to speak */
 #define	CHFL_DEOPPED 	0x0004	/* deopped by us, modes need to be bounced */
 #define	CHFL_BANNED     0x0008  /* is banned */
+#define	CHFL_HALFOP     0x0010  /* channel half-op */
 
 /* ban mask types */
 

--- a/src/channel.c
+++ b/src/channel.c
@@ -1202,13 +1202,47 @@ int is_chan_op(aClient *cptr, aChannel *chptr)
     return 0;
 }
 
+int is_chan_halfop(aClient *cptr, aChannel *chptr)
+{
+    chanMember   *cm;
+    
+    if (chptr)
+        if ((cm = find_user_member(chptr->members, cptr)))
+            return (cm->flags & CHFL_HALFOP);
+    
+    return 0;
+}
+
+/* A function to check if a user can use the kick command
+   Returns:
+   2 - user is an op (@)
+   1 - user is an half-op (%)
+   0 - user is not an op or half-op
+ */
+inline int is_chan_cankick(aClient *cptr, aChannel *chptr)
+{
+    chanMember   *cm;
+    
+    if (chptr)
+        if ((cm = find_user_member(chptr->members, cptr)))
+        {
+            if(cm->flags & CHFL_CHANOP)
+                return 2;
+            else if(cm->flags & CHFL_HALFOP)
+                return 1;
+            else return 0;
+        }
+    
+    return 0;
+}
+
 int is_chan_opvoice(aClient *cptr, aChannel *chptr)
 {
     chanMember   *cm;
     
     if (chptr)
         if ((cm = find_user_member(chptr->members, cptr)))
-            return ((cm->flags & CHFL_CHANOP) || (cm->flags & CHFL_VOICE));
+            return ((cm->flags & CHFL_CHANOP) || (cm->flags & CHFL_HALFOP) || (cm->flags & CHFL_VOICE));
     
     return 0;
 }
@@ -1349,7 +1383,7 @@ int can_send(aClient *cptr, aChannel *chptr, char *msg)
     else
     {
         /* ops and voices can talk through everything except NOCTRL */
-        if (!(cm->flags & (CHFL_CHANOP | CHFL_VOICE)))
+        if (!(cm->flags & (CHFL_CHANOP | CHFL_HALFOP | CHFL_VOICE)))
         {
             if (chptr->mode.mode & MODE_MODERATED)
                 return (MODE_MODERATED);
@@ -1633,6 +1667,10 @@ void send_channel_modes(aClient *cptr, aChannel *chptr)
         }
         if (l->flags & MODE_CHANOP)
             *t++ = '@';
+#ifdef USE_HALFOPS
+        if (l->flags & CHFL_HALFOP)
+            *t++ = '%';
+#endif
         if (l->flags & MODE_VOICE)
             *t++ = '+';
         strcpy(t, l->cptr->name);
@@ -1884,6 +1922,9 @@ static int set_mode(aClient *cptr, aClient *sptr, aChannel *chptr,
             }
             break;
         case 'o':
+#ifdef USE_HALFOPS
+        case 'h':
+#endif
         case 'v':
             if(level<1) 
             {
@@ -1924,8 +1965,15 @@ static int set_mode(aClient *cptr, aClient *sptr, aChannel *chptr,
             /* if we have the user, set them +/-[vo] */
             if(change=='+')
             {
-                int resend_nicklist = (chptr->mode.mode & MODE_AUDITORIUM) && MyClient(who) && !((cm->flags & CHFL_CHANOP) || (cm->flags & CHFL_VOICE));
-                cm->flags|=(*modes=='o' ? CHFL_CHANOP : CHFL_VOICE);
+                int resend_nicklist = (chptr->mode.mode & MODE_AUDITORIUM) && MyClient(who) && !((cm->flags & CHFL_CHANOP) || (cm->flags & CHFL_HALFOP) || (cm->flags & CHFL_VOICE));
+                switch(*modes)
+                {
+                    case 'o': cm->flags|= CHFL_CHANOP; break;
+#ifdef USE_HALFOPS
+                    case 'h': cm->flags|= CHFL_HALFOP; break;
+#endif
+                    case 'v': cm->flags|= CHFL_VOICE; break;
+                }
                 if (resend_nicklist)
                 {
                     char *fake_parv[3];
@@ -1952,7 +2000,14 @@ static int set_mode(aClient *cptr, aClient *sptr, aChannel *chptr,
             }
             else
             {
-                cm->flags&=~((*modes=='o' ? CHFL_CHANOP : CHFL_VOICE));
+                switch(*modes)
+                {
+                    case 'o': cm->flags&=~CHFL_CHANOP; break;
+#ifdef USE_HALFOPS
+                    case 'h': cm->flags&=~CHFL_HALFOP; break;
+#endif
+                    case 'v': cm->flags&=~CHFL_VOICE; break;
+                }
                 if(chptr->mode.mode & MODE_AUDITORIUM) sendto_channel_butserv_noopvoice(chptr, who, PartFmt, who->name, chptr->chname);
             }
             
@@ -3593,6 +3648,7 @@ int m_kick(aClient *cptr, aClient *sptr, int parc, char *parv[])
     int         chasing = 0;
     int         user_count;     /* count nicks being kicked, only allow 4 */
     char       *comment, *name, *p = NULL, *user, *p2 = NULL;
+    int        cankick = 0;
 
     if (parc < 3 || *parv[1] == '\0')
     {
@@ -3629,7 +3685,7 @@ int m_kick(aClient *cptr, aClient *sptr, int parc, char *parv[])
          * -Dianora
          */
 
-        if (!IsServer(sptr) && !is_chan_op(sptr, chptr) && !IsULine(sptr))
+        if (!IsServer(sptr) && !(cankick = is_chan_cankick(sptr, chptr)) && !IsULine(sptr))
         {
             /* was a user, not a server and user isn't seen as a chanop here */
 
@@ -3700,13 +3756,29 @@ int m_kick(aClient *cptr, aClient *sptr, int parc, char *parv[])
 
             if (IsMember(who, chptr))
             {
-#ifdef SPAMFILTER
                 if(MyClient(sptr))
                 {
+#ifdef SPAMFILTER
                     if(!(chptr->mode.mode & MODE_PRIVACY) && check_sf(sptr, comment, "kick", SF_CMD_KICK, chptr->chname))
                         return FLUSH_BUFFER;
-                }
 #endif
+#ifdef USE_HALFOPS
+                    if(cankick != 2)
+                    {
+                        chanMember *cm = find_user_member(chptr->members, who);
+                        if(cm)
+                        {
+                            /* Don't allow half-ops to kick ops, other half-ops or voiced users */
+                            if(cm->flags & (CHFL_CHANOP | CHFL_HALFOP | CHFL_VOICE))
+                            {
+                                sendto_one(sptr, err_str(ERR_CHANOPRIVSNEEDED),
+                                     me.name, parv[0], chptr->chname);
+                                return 0;
+                            }
+                        }
+                    }
+#endif
+                }
                 if((chptr->mode.mode & MODE_AUDITORIUM) && !is_chan_opvoice(who, chptr))
                 {
                     sendto_channelopvoice_butserv_me(chptr, sptr,
@@ -3878,7 +3950,11 @@ int m_topic(aClient *cptr, aClient *sptr, int parc, char *parv[])
             return 0;
         }
 
+#ifdef USE_HALFOPS
+        if ((chptr->mode.mode & MODE_TOPICLIMIT) && !is_chan_cankick(sptr, chptr))
+#else
         if ((chptr->mode.mode & MODE_TOPICLIMIT) && !is_chan_op(sptr, chptr))
+#endif
         {
             sendto_one(sptr, err_str(ERR_CHANOPRIVSNEEDED), me.name, parv[0],
                        chptr->chname);
@@ -4494,6 +4570,10 @@ int m_names(aClient *cptr, aClient *sptr, int parc, char *parv[])
             continue;
         if(cm->flags & CHFL_CHANOP)
             buf[idx++] = '@';
+#ifdef USE_HALFOPS
+        else if(cm->flags & CHFL_HALFOP)
+            buf[idx++] = '%';
+#endif
         else if(cm->flags & CHFL_VOICE)
             buf[idx++] = '+';
         else if((chptr->mode.mode & MODE_AUDITORIUM) && (sptr != acptr) && !is_chan_opvoice(sptr, chptr) && !IsAnOper(sptr)) continue;
@@ -5293,10 +5373,18 @@ int m_sjoin(aClient *cptr, aClient *sptr, int parc, char *parv[])
          s = s0 = strtoken(&p, (char *) NULL, " ")) 
     {
         fl = 0;
-        if (*s == '@' || s[1] == '@')
-            fl |= MODE_CHANOP;
-        if (*s == '+' || s[1] == '+')
-            fl |= MODE_VOICE;
+        while(*s == '@' || *s == '%' || *s == '+')
+        {
+            if (*s == '@')
+                fl |= MODE_CHANOP;
+#ifdef USE_HALFOPS
+            else if (*s == '%')
+                fl |= CHFL_HALFOP;
+#endif
+            else if (*s == '+')
+                fl |= MODE_VOICE;
+            s++;
+        }
         if (!keepnewmodes) 
         {
             if (fl & MODE_CHANOP)
@@ -5304,8 +5392,6 @@ int m_sjoin(aClient *cptr, aClient *sptr, int parc, char *parv[])
             else
                 fl = 0;
         }
-        while (*s == '@' || *s == '+')
-            s++;
         if (!(acptr = find_chasing(sptr, s, NULL)))
             continue;
         if (acptr->from != cptr)
@@ -5339,6 +5425,23 @@ int m_sjoin(aClient *cptr, aClient *sptr, int parc, char *parv[])
                 pargs = pbpos = 0;
             }
         }
+#ifdef USE_HALFOPS
+        if (fl & CHFL_HALFOP) 
+        {
+            *mbuf++ = 'h';
+            ADD_PARA(s)
+            pargs++;
+            if (pargs >= MAXMODEPARAMS) 
+            {
+                *mbuf = '\0';
+                parabuf[pbpos] = '\0';
+                sjoin_sendit(cptr, sptr, chptr, parv[0]);
+                mbuf = modebuf;
+                *mbuf++ = '+';
+                pargs = pbpos = 0;
+            }
+        }
+#endif
         if (fl & MODE_VOICE) 
         {
             *mbuf++ = 'v';

--- a/src/channel.c
+++ b/src/channel.c
@@ -1990,6 +1990,16 @@ static int set_mode(aClient *cptr, aClient *sptr, aChannel *chptr,
                 break;
             }
             
+#ifdef NO_LOCAL_CMODE_h
+            if(*modes=='h' && MyClient(sptr))
+            {
+                sendto_one(sptr,":%s NOTICE %s :*** Notice -- Half-ops are not fully supported yet.",
+                           me.name, sptr->name);
+                args++;
+                break;
+            }
+#endif
+
             /* if we have the user, set them +/-[vo] */
             if(change=='+')
             {

--- a/src/m_services.c
+++ b/src/m_services.c
@@ -999,13 +999,18 @@ int m_aj(aClient *cptr, aClient *sptr, int parc, char *parv[])
     fnick = nick = parv[1];
     nickts = atol(parv[2]);
 
-    while(*nick == '@' || *nick == '+')
+    while(*nick == '@' || *nick == '%' || *nick == '+')
     {
         switch(*nick)
         {
             case '@':
                 flags |= CHFL_CHANOP;
                 break;
+#ifdef USE_HALFOPS
+            case '%':
+                flags |= CHFL_HALFOP;
+                break;
+#endif
             case '+':
                 flags |= CHFL_VOICE;
                 break;
@@ -1070,6 +1075,11 @@ int m_aj(aClient *cptr, aClient *sptr, int parc, char *parv[])
                 if(flags & CHFL_CHANOP)
                  sendto_channel_butserv(chptr, sptr, ":%s MODE %s +o %s", sptr->name,
                                         chptr->chname, acptr->name);
+#ifdef USE_HALFOPS
+                if(flags & CHFL_HALFOP)
+                 sendto_channel_butserv(chptr, sptr, ":%s MODE %s +h %s", sptr->name,
+                                        chptr->chname, acptr->name);
+#endif
                 if(flags & CHFL_VOICE)
                  sendto_channel_butserv(chptr, sptr, ":%s MODE %s +v %s", sptr->name,
                                         chptr->chname, acptr->name);

--- a/src/s_debug.c
+++ b/src/s_debug.c
@@ -71,7 +71,12 @@ void build_rplcache(void)
     /* put MAXBANS and MAXCHANNELS first so better tokens override them */
     ircsprintf(scratchbuf,"NETWORK=%s SAFELIST MAXBANS=%i MAXCHANNELS=%i "
                "CHANNELLEN=%i KICKLEN=%i NICKLEN=%i TOPICLEN=%i MODES=%i "
-               "CHANTYPES=# CHANLIMIT=#:%i PREFIX=(ov)@+ STATUSMSG=@+",
+               "CHANTYPES=# CHANLIMIT=#:%i "
+#ifdef USE_HALFOPS
+               "PREFIX=(ohv)@%%%%+ STATUSMSG=@%%%%+",
+#else
+               "PREFIX=(ohv)@+ STATUSMSG=@+",
+#endif
                Network_Name, MAXBANS, maxchannelsperuser, CHANNELLEN,
                TOPICLEN, NICKLEN, TOPICLEN, MAXMODEPARAMSUSER,
                maxchannelsperuser);

--- a/src/s_user.c
+++ b/src/s_user.c
@@ -1623,6 +1623,10 @@ m_message(aClient *cptr, aClient *sptr, int parc, char *parv[], int notice)
         {
             if (*s == '@')
                 chflags |= CHFL_CHANOP;
+#ifdef USE_HALFOPS
+            else if (*s == '%')
+                chflags |= CHFL_HALFOP;
+#endif
             else if (*s == '+')
                 chflags |= CHFL_VOICE;
             else
@@ -1743,6 +1747,10 @@ m_message(aClient *cptr, aClient *sptr, int parc, char *parv[], int notice)
                 /* don't let clients do stuff like @+@@+++@+@@@#channel */
                 if (chflags & CHFL_VOICE)
                     *--s = '+';
+#ifdef USE_HALFOPS
+                if (chflags & CHFL_HALFOP)
+                    *--s = '%';
+#endif
                 if (chflags & CHFL_CHANOP)
                     *--s = '@';
 
@@ -2137,9 +2145,17 @@ m_whois(aClient *cptr, aClient *sptr, int parc, char *parv[])
                 }
                 if(!showchan) /* if we're not really supposed to show the chan
                                * but do it anyways, mark it as such! */
+#ifdef USE_HALFOPS
+                    *(buf + len++) = '~';
+#else
                     *(buf + len++) = '%';
+#endif
                 if (is_chan_op(acptr, chptr))
                     *(buf + len++) = '@';
+#ifdef USE_HALFOPS
+                else if (is_chan_halfop(acptr, chptr))
+                    *(buf + len++) = '%';
+#endif
                 else if (has_voice(acptr, chptr))
                     *(buf + len++) = '+';
                 if (len)


### PR DESCRIPTION
Half-ops will be able to (per #84):
- Kick users who aren't opped (+o) or voiced (+v)
- Change the channel topic even if +t is set (unless there is a topiclock but this will be enforced by services)

This feature can be enabled/disabled with the USE_HALFOPS define (enabled by default) but even when enabled, each channel can decide if they want to use this feature or not.

-Kobi.