### PR TITLE
Small change to the configure script

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -734,6 +734,12 @@ fi
 
 if test $prefix = NONE; then
     prefix=${HOME}/ircd
+    if test -f "${HOME}/bahamut/ircd" ; then
+        prefix=${HOME}/bahamut
+    fi
+    if test -f "${HOME}/dalnet/ircd" ; then
+        prefix=${HOME}/dalnet
+    fi
 fi
 
 INSTALL_DIR="${prefix}"


### PR DESCRIPTION
If no prefix is given as a parameter, check if ${HOME}/dalnet/ircd or ${HOME}/bahamut/ircd exists and use their directory as the default prefix.
If they don't exist, the default prefix will be used (${HOME}/ircd).

-Kobi.