### PR TITLE
Improve user host-masking support for WHO & RWHO

### DIFF
--- a/src/m_who.c
+++ b/src/m_who.c
@@ -621,9 +621,26 @@ int chk_who(aClient *ac, aClient *sptr, int showall)
 	    return 0;
     
     if(wsopts.host!=NULL)
+    {
+#ifdef USER_HOSTMASKING
+        if(IsAnOper(sptr))
+        {
+	    if((wsopts.host_plus && hchkfn(wsopts.host, ac->user->host) && hchkfn(wsopts.host, ac->user->mhost)) ||
+	       (!wsopts.host_plus && (!hchkfn(wsopts.host, ac->user->host) || !hchkfn(wsopts.host, ac->user->mhost))))
+	        return 0;
+        }
+        else
+        {
+	    if((wsopts.host_plus && hchkfn(wsopts.host, IsUmodeH(ac)?ac->user->mhost:ac->user->host)) ||
+	       (!wsopts.host_plus && !hchkfn(wsopts.host, IsUmodeH(ac)?ac->user->mhost:ac->user->host)))
+	        return 0;
+        }
+#else
 	if((wsopts.host_plus && hchkfn(wsopts.host, ac->user->host)) ||
 	   (!wsopts.host_plus && !hchkfn(wsopts.host, ac->user->host)))
 	    return 0;
+#endif
+    }
 
     if(wsopts.cidr_plus)
 	if(ac->ip_family != wsopts.cidr_family ||


### PR DESCRIPTION
Improve user host-masking support for WHO:
- Let IRC Operators /who +h and /who -h match both the masked and real host while users will only be able to match the user's current host (masked for umode +H and real for umode -H targets).

Improve user host-masking support for RWHO.
- New match flag: M will always show the masked host in the reply.
- New output flag: H (capital H) will show the user's masked host in the reply.
- /rwho +h and /rwho -h will match both masked and real hosts.

-Kobi.