### PR TITLE
Small fix to m_aj()

### DIFF
--- a/src/m_services.c
+++ b/src/m_services.c
@@ -1052,7 +1052,7 @@ int m_aj(aClient *cptr, aClient *sptr, int parc, char *parv[])
     if(nickts && acptr->tsinfo != nickts)
         return 0; /* tsinfo doesn't match */
 
-    if(*parv[2] == '0' && !atoi(parv[3]))
+    if(*parv[3] == '0' && !atoi(parv[3]))
     {
         if(acptr->user->channel == NULL)
             return 0; /* Target nick isn't on any channels */


### PR DESCRIPTION
The "JOIN 0" (part all channels) functionality of it was broken due to a typo bug. We don't need it for DALnet services, though.