### PR TITLE
Change "is now operator" to return umode instead of flag

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -126,6 +126,10 @@ msg_has_ctrls(char *msg)
         if (*c == 1)
             continue;
 
+		/* tab */
+		if (*c == 9)
+			continue;
+
         /* escape */
         if (*c == 27)
         {

--- a/src/channel.c
+++ b/src/channel.c
@@ -126,10 +126,6 @@ msg_has_ctrls(char *msg)
         if (*c == 1)
             continue;
 
-		/* tab */
-		if (*c == 9)
-			continue;
-
         /* escape */
         if (*c == 27)
         {

--- a/src/s_user.c
+++ b/src/s_user.c
@@ -3058,7 +3058,7 @@ int m_oper(aClient *cptr, aClient *sptr, int parc, char *parv[])
         throttle_remove(oper_ip);
         sendto_ops("%s (%s!%s@%s) is now operator (%c)", aoper->nick,
                    sptr->name, sptr->user->username, sptr->sockhost,
-                   IsOper(sptr) ? 'O' : 'o');
+                   IsOper(sptr) ? 'o' : 'O');
         send_umode_out(cptr, sptr, old);
         send_rplisupportoper(sptr);
         sendto_one(sptr, rpl_str(RPL_YOUREOPER), me.name, parv[0]);


### PR DESCRIPTION
Currently, this test is returning "O" for a network oper (+o) and "o" for a local oper (+O), the opposite of what the umodes actually are. I presume that most people receiving this message will not have config file access, so it seems better to send the umode instead of the config flags.