### PR TITLE
Allow tab characters with cmode +c

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -126,6 +126,10 @@ msg_has_ctrls(char *msg)
         if (*c == 1)
             continue;
 
+		/* tab */
+		if (*c == 9)
+			continue;
+
         /* escape */
         if (*c == 27)
         {

--- a/src/channel.c
+++ b/src/channel.c
@@ -126,9 +126,9 @@ msg_has_ctrls(char *msg)
         if (*c == 1)
             continue;
 
-		/* tab */
-		if (*c == 9)
-			continue;
+        /* tab */
+        if (*c == 9)
+            continue;
 
         /* escape */
         if (*c == 27)


### PR DESCRIPTION
Currently, messages containing the tab character(ASCII character 9) are prevented from being transmitted to a channel by the current check for ASCII characters less than 31. This patch is intended to preserve the intent of stopping control codes from being transmitted to a channel, while allowing messages containing the tab character to be transmitted. 