### PR TITLE
Fix our incorrect handling of IRC color code sequences

### DIFF
--- a/src/spamfilter.c
+++ b/src/spamfilter.c
@@ -494,17 +494,17 @@ void stripcolors(char new[512], char *org)
         {
             // Color codes: 1-2 digits, then optionally followed by a comma and an additional 1-2 digits
             org++;
-            if(*org && IsDigit(*org))
+            if(IsDigit(*org))
             {
                 org++;
-                if(*org && IsDigit(*org))
+                if(IsDigit(*org))
                 {
                     org++;
                 }
                 if(*org && *org == ',' && IsDigit(*(org + 1)))
                 {
                     org = org + 2;
-                    if(*org && IsDigit(*org))
+                    if(IsDigit(*org))
                     {
                         org++;
                     }
@@ -532,17 +532,17 @@ void stripall(char new[512], char *org)
         {
             // Color codes: 1-2 digits, then optionally followed by a comma and an additional 1-2 digits
             org++;
-            if(*org && IsDigit(*org))
+            if(IsDigit(*org))
             {
                 org++;
-                if(*org && IsDigit(*org))
+                if(IsDigit(*org))
                 {
                     org++;
                 }
                 if(*org && *org == ',' && IsDigit(*(org + 1)))
                 {
                     org = org + 2;
-                    if(*org && IsDigit(*org))
+                    if(IsDigit(*org))
                     {
                         org++;
                     }

--- a/src/spamfilter.c
+++ b/src/spamfilter.c
@@ -488,16 +488,33 @@ void stripcolors(char new[512], char *org)
 {
     int len = 0;
 
-    for(; (*org && len<512); org++)
+    for(; (*org && len < 512); org++)
     {
-        if(*org=='\003')
+        if(*org == '\003')
         {
+            // Color codes: 1-2 digits, then optionally followed by a comma and an additional 1-2 digits
             org++;
-            while(IsDigit(*org) || *org==',')
+            if(*org && IsDigit(*org))
+            {
                 org++;
+                if(*org && IsDigit(*org))
+                {
+                    org++;
+                }
+                if(*org && *org == ',' && IsDigit(*(org + 1)))
+                {
+                    org = org + 2;
+                    if(*org && IsDigit(*org))
+                    {
+                        org++;
+                    }
+                }
+            }
         }
-        if(*org<32)
+        if(*org < 32)
+        {
             continue;
+        }
         new[len++] = *org;
     }
     new[len] = '\0';
@@ -511,11 +528,26 @@ void stripall(char new[512], char *org)
 
     for(; (*org && len<512); org++)
     {
-        if(*org=='\003')
+        if(*org == '\003')
         {
+            // Color codes: 1-2 digits, then optionally followed by a comma and an additional 1-2 digits
             org++;
-            while(IsDigit(*org) || *org==',')
+            if(*org && IsDigit(*org))
+            {
                 org++;
+                if(*org && IsDigit(*org))
+                {
+                    org++;
+                }
+                if(*org && *org == ',' && IsDigit(*(org + 1)))
+                {
+                    org = org + 2;
+                    if(*org && IsDigit(*org))
+                    {
+                        org++;
+                    }
+                }
+            }
         }
         if(!fstripall(*org))
             continue;

--- a/src/spamfilter.c
+++ b/src/spamfilter.c
@@ -494,27 +494,21 @@ void stripcolors(char new[512], char *org)
         {
             // Color codes: 1-2 digits, then optionally followed by a comma and an additional 1-2 digits
             org++;
-            if(IsDigit(*org))
+            if(*org && IsDigit(*org))
             {
                 org++;
-                if(IsDigit(*org))
-                {
+                if(*org && IsDigit(*org))
                     org++;
-                }
                 if(*org && *org == ',' && IsDigit(*(org + 1)))
                 {
                     org = org + 2;
-                    if(IsDigit(*org))
-                    {
+                    if(*org && IsDigit(*org))
                         org++;
-                    }
                 }
             }
         }
         if(*org < 32)
-        {
             continue;
-        }
         new[len++] = *org;
     }
     new[len] = '\0';
@@ -532,20 +526,16 @@ void stripall(char new[512], char *org)
         {
             // Color codes: 1-2 digits, then optionally followed by a comma and an additional 1-2 digits
             org++;
-            if(IsDigit(*org))
+            if(*org && IsDigit(*org))
             {
                 org++;
-                if(IsDigit(*org))
-                {
+                if(*org && IsDigit(*org))
                     org++;
-                }
                 if(*org && *org == ',' && IsDigit(*(org + 1)))
                 {
                     org = org + 2;
-                    if(IsDigit(*org))
-                    {
+                    if(*org && IsDigit(*org))
                         org++;
-                    }
                 }
             }
         }


### PR DESCRIPTION
They follow the pattern 1-2 digits, then optionally followed by a comma and an additional 1-2 digits, but we were allowing an infinite number of digits and/or commas following the control code, which led to improper interpretation of strings.

For example, ^C4,1S^C073^C8x^C9y^C3L^C121^C6n^C4u^C7x^C8y^C9o^C3u^C12r^C6D^C4a^C7d^C8d^C9y^C was being stripped to "S8xyL6nux your Daddy" instead of "S3xyL1nux your Daddy" due to the "^C073" being stripped completely instead of just stripping the "^C07" and leaving the 3 as the original text, not a color code.