### PR TITLE
Fix SSL regression bug

### DIFF
--- a/include/libcrypto-compat.h
+++ b/include/libcrypto-compat.h
@@ -1,6 +1,8 @@
 #ifndef LIBCRYPTO_COMPAT_H
 #define LIBCRYPTO_COMPAT_H
 
+#ifdef USE_SSL
+
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 
 #include <openssl/dh.h>
@@ -12,5 +14,7 @@ int DH_set0_key(DH *dh, BIGNUM *pub_key, BIGNUM *priv_key);
 int DH_set_length(DH *dh, long length);
 
 #endif /* OPENSSL_VERSION_NUMBER */
+
+#endif /* USE_SSL */
 
 #endif /* LIBCRYPTO_COMPAT_H */

--- a/src/libcrypto-compat.c
+++ b/src/libcrypto-compat.c
@@ -7,6 +7,8 @@
  * https://www.openssl.org/source/license.html
  */
 
+#ifdef USE_SSL
+
 #include "struct.h"
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
@@ -87,3 +89,5 @@ int DH_set_length(DH *dh, long length)
 }
 
 #endif /* OPENSSL_VERSION_NUMBER */
+
+#endif /* USE_SSL */


### PR DESCRIPTION
Only use libcrypto-compat code if SSL is enabled.

Per Colby Ross via dalnet-src@DAL.net