### PR TITLE
Improve user host-masking support for WHO & RWHO

### DIFF
--- a/include/struct.h
+++ b/include/struct.h
@@ -1535,6 +1535,7 @@ typedef struct SearchOptions
     unsigned search_chan:1;
     unsigned ip_show:1;
     unsigned realhost_show:1;
+    unsigned maskhost_show:1;
     unsigned client_type_plus:1;
 } SOpts;
 


### PR DESCRIPTION
Updates to Kobi's original PR (https://github.com/DALnet/bahamut/pull/103) after online discussion.

Improve user host-masking support for WHO:

-    Let IRC Operators /who +h and /who -h match both the masked and real host while users will only be able to match the user's current host (masked for umode +H and real for umode -H targets).
- New behavior flag: H will show the user's masked host in the reply.

Improve user host-masking support for RWHO.

- New output flag: H will show the user's masked host in the reply.
- New output flag: R will show the user's real/unmasked host in the reply.
- /rwho +h and /rwho -h will match both masked and real hosts.
