### PR TITLE
Fix /whois channel name truncation

### DIFF
--- a/src/s_user.c
+++ b/src/s_user.c
@@ -2133,8 +2133,8 @@ m_whois(aClient *cptr, aClient *sptr, int parc, char *parv[])
                        name, user->real_oper_username, user->real_oper_host,
                        user->real_oper_ip);
 #endif
-#endif          
-        mlen = strlen(me.name) + strlen(parv[0]) + 6 + strlen(name);
+#endif
+        mlen = strlen(me.name) + strlen(parv[0]) + 8 + strlen(name);
         for (len = 0, *buf = '\0', lp = user->channel; lp; lp = lp->next)
         {
             chptr = lp->value.chptr;
@@ -2143,8 +2143,7 @@ m_whois(aClient *cptr, aClient *sptr, int parc, char *parv[])
             {
                 if (len + strlen(chptr->chname) > (size_t) BUFSIZE - 4 - mlen)
                 {
-                    sendto_one(sptr, ":%s %d %s %s :%s", me.name, 
-                               RPL_WHOISCHANNELS, parv[0], name, buf);
+                    sendto_one(sptr, rpl_str(RPL_WHOISCHANNELS), me.name, parv[0], name, buf);
                     *buf = '\0';
                     len = 0;
                 }

--- a/src/s_user.c
+++ b/src/s_user.c
@@ -2134,7 +2134,7 @@ m_whois(aClient *cptr, aClient *sptr, int parc, char *parv[])
                        user->real_oper_ip);
 #endif
 #endif
-        mlen = strlen(me.name) + strlen(parv[0]) + 8 + strlen(name);
+        mlen = strlen(me.name) + strlen(parv[0]) + 9 + strlen(name);
         for (len = 0, *buf = '\0', lp = user->channel; lp; lp = lp->next)
         {
             chptr = lp->value.chptr;


### PR DESCRIPTION
brandon noticed that if a user is in a ton of channels, therefore requiring two RPL_WHOISCHANNELS reply lines, the last channel name in the first reply is sometimes truncated by a character or two.

After much debugging, it seems like the initial string length (mlen) was not set correctly.

`/* 319 RPL_WHOISCHANNELS */	":%s 319 %s %s :%s",`

If we count the non-parameter characters, we have colon, space, 3, 1, 9, space, space, space, and colon, which totals 9.  This was originally set to 6.

Also updated the reply to use rpl_str() instead of hardcoding the template in case someone wanted to customize it (crazy talk!).