### PR TITLE
Allow squelched users to send messages to the services and stats addresses

### DIFF
--- a/src/s_user.c
+++ b/src/s_user.c
@@ -1551,7 +1551,7 @@ send_msg_error(aClient *sptr, char *parv[], char *nick, int ret, aChannel *chptr
 static int is_aliastab_recipient(char *recipient)
 {
     AliasInfo *ai;
-    char full_target[USERLEN + HOSTLEN + 2];
+    char full_target[NICKLEN + HOSTLEN + 2];
 
     for(ai = aliastab; ai->nick; ai++)
     {

--- a/src/s_user.c
+++ b/src/s_user.c
@@ -1546,6 +1546,24 @@ send_msg_error(aClient *sptr, char *parv[], char *nick, int ret, aChannel *chptr
 }
 
 /*
+ * Check if the recipient we are sending to is one of the services or stats addresses.
+ */
+static int is_aliastab_recipient(char *recipient)
+{
+    AliasInfo *ai;
+    char full_target[USERLEN + HOSTLEN + 2];
+
+    for(ai = aliastab; ai->nick; ai++)
+    {
+        ircsprintf(full_target, "%s@%s", ai->nick, ai->server);
+        if(!mycmp(recipient, full_target))
+            return 1;
+    }
+
+    return 0;
+}
+
+/*
  * m_message (used in m_private() and m_notice()) the general
  * function to deliver MSG's between users/channels
  * 
@@ -1590,11 +1608,12 @@ m_message(aClient *cptr, aClient *sptr, int parc, char *parv[], int notice)
     if (ismine)
     {
         /* if squelched or spamming, allow only messages to self */
+        /* if warn squelched, allow messages to the services and stats addresses */
         if ((IsSquelch(sptr)
 #if defined(ANTI_SPAMBOT) && !defined(ANTI_SPAMBOT_WARN_ONLY)
             || (sptr->join_leave_count >= MAX_JOIN_LEAVE_COUNT)
 #endif
-            ) && mycmp(parv[0], parv[1]))
+            ) && mycmp(parv[0], parv[1]) && ((IsWSquelch(sptr) && !is_aliastab_recipient(parv[1])) || !IsWSquelch(sptr)))
         {
             if (IsWSquelch(sptr) && !notice)
                 sendto_one(sptr, ":%s NOTICE %s :You are currently squelched."

--- a/src/s_user.c
+++ b/src/s_user.c
@@ -1607,13 +1607,12 @@ m_message(aClient *cptr, aClient *sptr, int parc, char *parv[], int notice)
 
     if (ismine)
     {
-        /* if squelched or spamming, allow only messages to self */
-        /* if warn squelched, allow messages to the services and stats addresses */
+        /* if squelched or spamming, allow only messages to self or to the services and stats addresses */
         if ((IsSquelch(sptr)
 #if defined(ANTI_SPAMBOT) && !defined(ANTI_SPAMBOT_WARN_ONLY)
             || (sptr->join_leave_count >= MAX_JOIN_LEAVE_COUNT)
 #endif
-            ) && mycmp(parv[0], parv[1]) && ((IsWSquelch(sptr) && !is_aliastab_recipient(parv[1])) || !IsWSquelch(sptr)))
+            ) && mycmp(parv[0], parv[1]) && !is_aliastab_recipient(parv[1]))
         {
             if (IsWSquelch(sptr) && !notice)
                 sendto_one(sptr, ":%s NOTICE %s :You are currently squelched."


### PR DESCRIPTION
We currently squelch (+x) users on VPN connections and require them to use a registered nick to remove the squelch.  While the /nickserv (and equivalent) aliases work through squelches, the /msg nickserv@services.dal.net (and equivalent) syntax does not.  This results in help queries in #operhelp for people trying to identify or register a nick using /msg instead of /nickserv.

This will allow squelched users to message any of the aliastab recipients (services or stats nicks).

I am curious what @kobishmueli thinks about this approach.  I am open to discussion if someone thinks there's a better way to handle.