### PR TITLE
Specify the channel that is +M or +R.

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -2854,7 +2854,7 @@ static int can_join(aClient *sptr, aChannel *chptr, char *key)
 
         if (error==ERR_NEEDREGGEDNICK)
             sendto_one(sptr, getreply(ERR_NEEDREGGEDNICK), me.name, sptr->name,
-                       chptr->chname, "join", aliastab[AII_NS].nick,
+                       chptr->chname, "join", chptr->chname, aliastab[AII_NS].nick,
                        aliastab[AII_NS].server, NS_Register_URL);
         else
             sendto_one(sptr, getreply(error), me.name, sptr->name,

--- a/src/s_err.c
+++ b/src/s_err.c
@@ -534,8 +534,8 @@ static char *replies[] =
     /* 475 ERR_BADCHANNELKEY */	":%s 475 %s %s :Cannot join channel (+k)",
     /* 476 ERR_BADCHANMASK */	":%s 476 %s %s :Bad Channel Mask",
     /* 477 ERR_NEEDREGGEDNICK */       ":%s 477 %s %s :You need to identify "
-                                       "to a registered nick to %s that "
-                                       "channel. For help with registering "
+                                       "to a registered nick to %s "
+                                       "%s. For help with registering "
                                        "your nickname, type \"/msg %s@%s help "
                                        "register\" or see %s",
     /* 478 ERR_BANLISTFULL */	":%s 478 %s %s %s :Channel %s list is full",

--- a/src/s_user.c
+++ b/src/s_user.c
@@ -1535,7 +1535,7 @@ send_msg_error(aClient *sptr, char *parv[], char *nick, int ret, aChannel *chptr
     }
     else if(ret == ERR_NEEDREGGEDNICK)
         sendto_one(sptr, err_str(ERR_NEEDREGGEDNICK), me.name,
-                   parv[0], nick, "speak in", aliastab[AII_NS].nick,
+                   parv[0], nick, "speak in", chptr->chname, aliastab[AII_NS].nick,
                    aliastab[AII_NS].server, NS_Register_URL);
     else if(ret == ERR_MAXMSGSENT)
         sendto_one(sptr, err_str(ERR_MAXMSGSENT), me.name,


### PR DESCRIPTION
My client tried to autojoin a bunch of channels before I had identified and I got two generic messages saying, "You need to identify to a registered nick to join that channel."  It seems silly not to tell them which channel the error is for, as I had to go hunting to figure it out which channels had failed.