### PR TITLE
Add SVSCTRL command to let services control services join requests

### DIFF
--- a/include/msg.h
+++ b/include/msg.h
@@ -238,6 +238,7 @@ extern int m_sf(aClient *, aClient *, int, char **);
 extern int m_aj(aClient *, aClient *, int, char **);
 extern int m_sjr(aClient *, aClient *, int, char **, AliasInfo *);
 extern int m_svsxcf(aClient *, aClient *, int, char **);
+extern int m_svsctrl(aClient *, aClient *, int, char **);
 
 /* aliastab indexes */
 #define AII_NS  0
@@ -374,6 +375,7 @@ struct Message msgtab[] =
     {"SPAMOPS",    m_spamops,  MAXPARA, 0,        0},
     {"SF",         m_sf,       MAXPARA, 0,        0},
     {"SVSXCF",     m_svsxcf,   MAXPARA, 0,        0},
+    {"SVSCTRL",    m_svsctrl,  MAXPARA, 0,        0},
     {"AJ",         m_aj,       MAXPARA, 0,        0},
     {"SJR",        m_sjr,      MAXPARA, MF_ALIAS, AII_NS},
     {MSG_WEBIRC,   m_webirc,   MAXPARA, MF_UNREG, 0},

--- a/src/m_services.c
+++ b/src/m_services.c
@@ -1146,6 +1146,39 @@ int m_sjr(aClient *cptr, aClient *sptr, int parc, char *parv[], AliasInfo *ai)
     return 0;
 }
 
+/* m_svsctrl - Lets services control join requests (will be extended to support other settings in the future)
+ * parv[0] - sender
+ * parv[1] - setting
+ * parv[2] - value
+ */
+int m_svsctrl(aClient *cptr, aClient *sptr, int parc, char *parv[])
+{
+    if(!IsULine(sptr) || parc<4)
+        return 0;
+
+    if(parc==4 && (hunt_server(cptr, sptr, ":%s SVSCTRL %s %s :%s", 1, parc, parv) != HUNTED_ISME))
+        return 0;
+    if(parc==5 && (hunt_server(cptr, sptr, ":%s SVSCTRL %s %s %s :%s", 1, parc, parv) != HUNTED_ISME))
+        return 0;
+    if(parc==6 && (hunt_server(cptr, sptr, ":%s SVSCTRL %s %s %s %s :%s", 1, parc, parv) != HUNTED_ISME))
+        return 0;
+    if(parc==7 && (hunt_server(cptr, sptr, ":%s SVSCTRL %s %s %s %s %s :%s", 1, parc, parv) != HUNTED_ISME))
+        return 0;
+    if(parc==8 && (hunt_server(cptr, sptr, ":%s SVSCTRL %s %s %s %s %s %s :%s", 1, parc, parv) != HUNTED_ISME))
+        return 0;
+    if(parc==9 && (hunt_server(cptr, sptr, ":%s SVSCTRL %s %s %s %s %s %s %s :%s", 1, parc, parv) != HUNTED_ISME))
+        return 0;
+    if(parc!=4 && parc!=5 && parc!=6 && parc!=7 && parc!=8 && parc!=9) return 0; /* Just in case... */
+
+    if(!mycmp(parv[2], "SJR"))
+    {
+        services_jr = atoi(parv[3]);
+        return 0;
+    }
+
+    return 0;
+}
+
 u_long
 memcount_m_services(MCm_services *mc)
 {


### PR DESCRIPTION
To enable services join requests, services will send:
SVSCTRL server.dal.net SJR 1

To disable services join requests, services will send:
SVSCTRL server.dal.net SJR 0

(server.dal.net can be replaced by * to send it to all servers)

The current implementation of SVSCTRL is written to support other features
that might be added in the future without the need to upgrade all the hubs
on the network.

-Kobi.