### PR TITLE
Add RuneB's WEBIRC description to reference.conf

### DIFF
--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -399,7 +399,24 @@ allow {
 # 
 # Using the examples in this file, a client could connect with the password
 # string "secret:johndoe:secret" and be masked as johndoe@staff.net.
-# 
+#
+# The WEBIRC command identifies trusted clients, and permits the real
+# hostname of a webirc client be used instead of the hostname of the
+# webirc gateway they connected through. This can be used to prevent users
+# from having ircip1.mibbit.com as their hostname, for example.
+#
+# Trusted clients are added to the ircd.conf by adding special allow
+# blocks that match ident@host (if an identd response was received), or
+# webirc@host (if not), and that use a password of the form:
+# webirc.<password>
+#
+# For example:
+#
+# allow { ipmask webirc@127.0.0.1; passwd webirc.mypass; class users; };
+#
+# will allow the command to be used from a non-identd client connecting
+# from 127.0.0.1 if they use the password mypass in the WEBIRC command.
+#
 # The flags token allows special behavior to be assigned to this
 # connection, using a set of single-letter options.  The available flags
 # are:


### PR DESCRIPTION
This adds [RuneB's WEBIRC description](https://github.com/DALnet/bahamut/commit/a86bfecd5b134a2eec7ea30a28fa49ead8683aff) into the reference.conf helping to make clear the proper way to enable WEBIRC authentication for trusted clients.