### PR TITLE
Allows local operators to UMODE +F

### DIFF
--- a/include/struct.h
+++ b/include/struct.h
@@ -500,7 +500,7 @@ typedef struct SServicesTag ServicesTag;
                          OFLAG_UNKLINE|OFLAG_LNOTICE|OFLAG_UMODEc|OFLAG_UMODEf|OFLAG_UMODEd|\
                          OFLAG_UMODEb|OFLAG_UMODEy)
 #define OFLAG_GLOBAL	(OFLAG_LOCAL|OFLAG_GROUTE|OFLAG_GKILL|OFLAG_GNOTICE)
-#define OFLAG_ISGLOBAL	(OFLAG_GROUTE|OFLAG_GKILL|OFLAG_GNOTICE|OFLAG_SADMIN|OFLAG_UMODEF)
+#define OFLAG_ISGLOBAL	(OFLAG_GROUTE|OFLAG_GKILL|OFLAG_GNOTICE|OFLAG_SADMIN)
 #define OPCanZline(x)	        ((x)->oflag & OFLAG_SADMIN)
 #define OPCanRehash(x)	        ((x)->oflag & OFLAG_REHASH)
 #define OPCanDie(x)	        ((x)->oflag & OFLAG_DIE)


### PR DESCRIPTION
OFLAG_UMODEF automatically made OFLAG_ISGLOBAL true.  With this, local O and global o's can have the F flag added to their oper block.  This is in reference to: https://github.com/DALnet/bahamut/issues/144