### PR TITLE
152: Clean up libcrypto-compat declarations.

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -470,7 +470,7 @@ if test "X$cf_enable_openssl" != "Xno" ; then
     cf_enable_openssl="yes"
     encryption="enabled"
     AC_DEFINE(HAVE_ENCRYPTION_ON)
-    ENCRYPT_SRC="rc4.c dh.c"
+    ENCRYPT_SRC="rc4.c dh.c libcrypto-compat.c"
     AC_SUBST(ENCRYPT_SRC)
   else
     AC_MSG_RESULT(not found.  Please check your path.)

--- a/include/libcrypto-compat.h
+++ b/include/libcrypto-compat.h
@@ -1,6 +1,7 @@
 #ifndef LIBCRYPTO_COMPAT_H
 #define LIBCRYPTO_COMPAT_H
 
+#include <struct.h>
 #ifdef USE_SSL
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L

--- a/include/struct.h
+++ b/include/struct.h
@@ -56,7 +56,6 @@
 #include <openssl/pem.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
-#include "libcrypto-compat.h"
 #endif
 
 #define REPORT_DO_DNS_	   ":%s NOTICE AUTH :*** Looking up your hostname..."

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -18,7 +18,7 @@ RES_SRC =
 
 SOURCES = blalloc.c bsd.c channel.c clientlist.c clones.c confparse.c \
           fdlist.c fds.c hash.c hide.c inet_addr.c ircd.c \
-          klines.c libcrypto-compat.c list.c m_nick.c m_rwho.c m_server.c m_services.c \
+          klines.c list.c m_nick.c m_rwho.c m_server.c m_services.c \
           m_stats.c m_who.c match.c memcount.c modules.c packet.c parse.c pcre.c \
           probability.c res.c s_auth.c s_bsd.c s_conf.c s_debug.c s_err.c \
           s_misc.c s_numeric.c s_serv.c s_user.c sbuf.c scache.c send.c \

--- a/src/ircd.c
+++ b/src/ircd.c
@@ -47,7 +47,6 @@
 #include "hooks.h"
 #include "fds.h"
 #include "memcount.h"
-#include "libcrypto-compat.h"
 #include "spamfilter.h"
 
 aMotd      *motd;

--- a/src/libcrypto-compat.c
+++ b/src/libcrypto-compat.c
@@ -7,9 +7,8 @@
  * https://www.openssl.org/source/license.html
  */
 
-#ifdef USE_SSL
-
 #include "struct.h"
+#ifdef USE_SSL
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 


### PR DESCRIPTION
Fix OpenSSL compile errors for version < 1.1.0 as reported in #152 