### PR TITLE
158: Increase default key size from 1024 to 2048 as a best practice.

### DIFF
--- a/tools/make-cert.cnf
+++ b/tools/make-cert.cnf
@@ -3,7 +3,7 @@
 RANDFILE = make-cert.rnd
 
 [ req ]
-default_bits = 1024
+default_bits = 2048
 encrypt_key = yes
 distinguished_name = req_dn
 x509_extensions = cert_type


### PR DESCRIPTION
Fixes #158 