### PR TITLE
Fixes issue #180

### DIFF
--- a/src/s_conf.c
+++ b/src/s_conf.c
@@ -383,7 +383,6 @@ find_oper(char *name, char *username, char *sockhost, char *hostip)
     char userhost[USERLEN + HOSTLEN + 3];
     char userip[USERLEN + HOSTLEN + 3];
     int i;
-    int nickmatch=0;
 
     /* sockhost OR hostip must match our host field */
 
@@ -395,15 +394,13 @@ find_oper(char *name, char *username, char *sockhost, char *hostip)
     {
         if (aoper->legal == -1)
             continue;
-        if(!mycmp(name, aoper->nick))
-            nickmatch=1;
-        else
+        if(mycmp(name, aoper->nick))
             continue;
 
         for(i = 0; aoper->hosts[i]; i++)
         {
-            if(nickmatch && (!match(aoper->hosts[i], userhost)
-                    || !match(aoper->hosts[i], userip)))
+            if(!match(aoper->hosts[i], userhost)
+                    || !match(aoper->hosts[i], userip))
                 return aoper;
             if(strchr(aoper->hosts[i], '/'))
             {
@@ -431,7 +428,7 @@ find_oper(char *name, char *username, char *sockhost, char *hostip)
                 {
                     /* Check the wildcards in the rest of the string. */
                     ircsprintf(cidrbuf, "%s@%s", username, s);
-                    if (!match(aoper->hosts[i], cidrbuf) && nickmatch)
+                    if (!match(aoper->hosts[i], cidrbuf))
                         return aoper;
                 }
             }

--- a/src/s_conf.c
+++ b/src/s_conf.c
@@ -383,7 +383,7 @@ find_oper(char *name, char *username, char *sockhost, char *hostip)
     char userhost[USERLEN + HOSTLEN + 3];
     char userip[USERLEN + HOSTLEN + 3];
     int i;
-    int nickmatch;
+    int nickmatch=0;
 
     /* sockhost OR hostip must match our host field */
 
@@ -395,11 +395,13 @@ find_oper(char *name, char *username, char *sockhost, char *hostip)
     {
         if (aoper->legal == -1)
             continue;
+        if(!mycmp(name, aoper->nick))
+            nickmatch=1;
+        else
+            continue;
 
         for(i = 0; aoper->hosts[i]; i++)
         {
-            if(!mycmp(name, aoper->nick))
-                nickmatch=1;
             if(nickmatch && (!match(aoper->hosts[i], userhost)
                     || !match(aoper->hosts[i], userip)))
                 return aoper;

--- a/src/s_conf.c
+++ b/src/s_conf.c
@@ -392,10 +392,7 @@ find_oper(char *name, char *username, char *sockhost, char *hostip)
 
     for(aoper = opers; aoper; aoper = aoper->next)
     {
-        if (aoper->legal == -1)
-            continue;
-
-        if(mycmp(name, aoper->nick))
+        if (aoper->legal == -1 || mycmp(name, aoper->nick))
             continue;
 
         for(i = 0; aoper->hosts[i]; i++)

--- a/src/s_conf.c
+++ b/src/s_conf.c
@@ -394,6 +394,7 @@ find_oper(char *name, char *username, char *sockhost, char *hostip)
     {
         if (aoper->legal == -1)
             continue;
+
         if(mycmp(name, aoper->nick))
             continue;
 
@@ -402,36 +403,36 @@ find_oper(char *name, char *username, char *sockhost, char *hostip)
             if(!match(aoper->hosts[i], userhost)
                     || !match(aoper->hosts[i], userip))
                 return aoper;
-            if(strchr(aoper->hosts[i], '/'))
-            {
-                char cidrbuf[USERLEN + HOSTLEN + 3];
-                char ipbuf1[16], ipbuf2[16];
-                char *s;
-                int bits;
-                int family;
+	    if(strchr(aoper->hosts[i], '/'))
+	    {
+		char cidrbuf[USERLEN + HOSTLEN + 3];
+		char ipbuf1[16], ipbuf2[16];
+		char *s;
+		int bits;
+		int family;
 
-                s = strchr(aoper->hosts[i], '@');
-                if (s)
-                    s++;
-                else
-                    s = aoper->hosts[i];
+		s = strchr(aoper->hosts[i], '@');
+		if (s)
+		    s++;
+		else
+		    s = aoper->hosts[i];
 
-                if (inet_pton(AF_INET, hostip, ipbuf1) == 1)
-                    family = AF_INET;
-                else if (inet_pton(AF_INET6, hostip, ipbuf1) == 1)
-                    family = AF_INET6;
-                else
-                    family = 0;
+		if (inet_pton(AF_INET, hostip, ipbuf1) == 1)
+		    family = AF_INET;
+		else if (inet_pton(AF_INET6, hostip, ipbuf1) == 1)
+		    family = AF_INET6;
+		else
+		    family = 0;
 
-                bits = inet_parse_cidr(family, s, ipbuf2, sizeof(ipbuf2));
-                if (bits > 0 && bitncmp(ipbuf1, ipbuf2, bits) == 0)
-                {
-                    /* Check the wildcards in the rest of the string. */
-                    ircsprintf(cidrbuf, "%s@%s", username, s);
-                    if (!match(aoper->hosts[i], cidrbuf))
-                        return aoper;
-                }
-            }
+		bits = inet_parse_cidr(family, s, ipbuf2, sizeof(ipbuf2));
+		if (bits > 0 && bitncmp(ipbuf1, ipbuf2, bits) == 0)
+		{
+		    /* Check the wildcards in the rest of the string. */
+		    ircsprintf(cidrbuf, "%s@%s", username, s);
+		    if (match(aoper->hosts[i], cidrbuf) == 0)
+			return aoper;
+		}
+	    }
         }
     }
     return NULL;
@@ -560,44 +561,44 @@ attach_Iline(aClient *cptr, struct hostent *hp, char *sockhost)
             {
                 if (!match(allow->ipmask, useriphost))
                     return (attach_iline(cptr, allow, iphost, 1));
-  else if (strchr(allow->ipmask, '/'))
-  {
-      char cidrbuf[USERLEN + 1 + HOSTLEN + 1];
-      char ipbuf[16];
-      char *s;
-      int bits;
+		else if (strchr(allow->ipmask, '/'))
+		{
+		    char cidrbuf[USERLEN + 1 + HOSTLEN + 1];
+		    char ipbuf[16];
+		    char *s;
+		    int bits;
 
-      s = strchr(allow->ipmask, '@');
-      if (s)
-  s++;
-      else
-  continue;
+		    s = strchr(allow->ipmask, '@');
+		    if (s)
+			s++;
+		    else
+			continue;
 
-      bits = inet_parse_cidr(cptr->ip_family, s,
-     ipbuf, sizeof(ipbuf));
-      if (bits > 0 && bitncmp(&cptr->ip, ipbuf, bits) == 0)
-      {
-  /* Check the wildcards in the rest of the string. */
-  ircsprintf(cidrbuf, "%s@%s", cptr->username, s);
-  if (match(allow->ipmask, cidrbuf) == 0)
-      return (attach_iline(cptr, allow, iphost, 1));
-      }
-  }
+		    bits = inet_parse_cidr(cptr->ip_family, s,
+					   ipbuf, sizeof(ipbuf));
+		    if (bits > 0 && bitncmp(&cptr->ip, ipbuf, bits) == 0)
+		    {
+			/* Check the wildcards in the rest of the string. */
+			ircsprintf(cidrbuf, "%s@%s", cptr->username, s);
+			if (match(allow->ipmask, cidrbuf) == 0)
+			    return (attach_iline(cptr, allow, iphost, 1));
+		    }
+		}
             }
             else
             {
                 if (!match(allow->ipmask, iphost))
                     return (attach_iline(cptr, allow, iphost, 0));
-  else if (strchr(allow->ipmask, '/'))
-  {
-      char ipbuf[16];
-      int bits;
+		else if (strchr(allow->ipmask, '/'))
+		{
+		    char ipbuf[16];
+		    int bits;
 
-      bits = inet_parse_cidr(cptr->ip_family, allow->ipmask,
-     ipbuf, sizeof(ipbuf));
-      if (bits > 0 && bitncmp(&cptr->ip, ipbuf, bits) == 0)
-  return (attach_iline(cptr, allow, iphost, 1));
-  }
+		    bits = inet_parse_cidr(cptr->ip_family, allow->ipmask,
+					   ipbuf, sizeof(ipbuf));
+		    if (bits > 0 && bitncmp(&cptr->ip, ipbuf, bits) == 0)
+			return (attach_iline(cptr, allow, iphost, 1));
+		}
             }
         }
     }
@@ -955,45 +956,45 @@ confadd_connect(cVar *vars[], int lnum)
 
     if(x->source)
     {
-  union
-  {
-      struct sockaddr_in ip4;
-      struct sockaddr_in6 ip6;
-  } tmp_addr;
-  int host_family, source_family;
-  const char *s;
+	union
+	{
+	    struct sockaddr_in ip4;
+	    struct sockaddr_in6 ip6;
+	} tmp_addr;
+	int host_family, source_family;
+	const char *s;
 
-  s = strchr(x->host, '@');
-  if (s)
-      s++;
-  else
-      s = x->host;
+	s = strchr(x->host, '@');
+	if (s)
+	    s++;
+	else
+	    s = x->host;
 
-  if (inet_pton(AF_INET, s, &tmp_addr.ip4) == 1)
-      host_family = AF_INET;
-  else if (inet_pton(AF_INET6, s, &tmp_addr.ip6) == 1)
-      host_family = AF_INET6;
-  else
-      host_family = 0;
+	if (inet_pton(AF_INET, s, &tmp_addr.ip4) == 1)
+	    host_family = AF_INET;
+	else if (inet_pton(AF_INET6, s, &tmp_addr.ip6) == 1)
+	    host_family = AF_INET6;
+	else
+	    host_family = 0;
 
-  if (inet_pton(AF_INET, x->source, &tmp_addr.ip4) == 1)
-      source_family = AF_INET;
-  else if (inet_pton(AF_INET6, x->source, &tmp_addr.ip6) == 1)
-      source_family = AF_INET6;
-  else
-  {
-      confparse_error("Invalid source address in connect block", lnum);
-      free_connect(x);
-      return -1;
-  }
+	if (inet_pton(AF_INET, x->source, &tmp_addr.ip4) == 1)
+	    source_family = AF_INET;
+	else if (inet_pton(AF_INET6, x->source, &tmp_addr.ip6) == 1)
+	    source_family = AF_INET6;
+	else
+	{
+	    confparse_error("Invalid source address in connect block", lnum);
+	    free_connect(x);
+	    return -1;
+	}
 
-  if (host_family != 0 && host_family != source_family)
-  {
-      confparse_error("Address family of host does not match "
-      "address family of source in connect block", lnum);
-      free_connect(x);
-      return -1;
-  }
+	if (host_family != 0 && host_family != source_family)
+	{
+	    confparse_error("Address family of host does not match "
+			    "address family of source in connect block", lnum);
+	    free_connect(x);
+	    return -1;
+	}
     }
     x->next = new_connects;
     new_connects = x;
@@ -1146,8 +1147,8 @@ confadd_options(cVar *vars[], int lnum)
             tmp->type = NULL;
             tswarndelta = atoi(tmp->value);
         }
-  else if(tmp->type && (tmp->type->flag & OPTF_REMREHOK))
-  {
+	else if(tmp->type && (tmp->type->flag & OPTF_REMREHOK))
+	{
             tmp->type = NULL;
             new_confopts |= FLAGS_REMREHOK;
         }
@@ -2350,15 +2351,15 @@ int rehash(aClient *cptr, aClient *sptr, int sig)
     if (sig == SIGHUP)
     {
 #ifdef USE_SSL
-  /* Rehash SSL so we can automate certificate renewals and updates externally, i.e. from a cron job --xPsycho */
-  sendto_ops("Got signal SIGHUP, rehashing SSL");
-  ssl_rehash();
+		/* Rehash SSL so we can automate certificate renewals and updates externally, i.e. from a cron job --xPsycho */
+		sendto_ops("Got signal SIGHUP, rehashing SSL");
+		ssl_rehash();
 #endif
         sendto_ops("Got signal SIGHUP, reloading ircd conf. file");
         remove_userbans_match_flags(UBAN_NETWORK, 0);
         /* remove all but kill {} blocks from conf */
         remove_userbans_match_flags(UBAN_LOCAL, UBAN_CONF);
-  remove_simbans_match_flags(SBAN_NICK|SBAN_LOCAL|SBAN_TEMPORARY, SBAN_SVSHOLD);
+	remove_simbans_match_flags(SBAN_NICK|SBAN_LOCAL|SBAN_TEMPORARY, SBAN_SVSHOLD);
         remove_simbans_match_flags(SBAN_CHAN|SBAN_LOCAL|SBAN_TEMPORARY, 0);
         remove_simbans_match_flags(SBAN_GCOS|SBAN_LOCAL|SBAN_TEMPORARY, 0);
         throttle_rehash();
@@ -2442,51 +2443,51 @@ static int lookup_confhost(aConnect *aconn)
      */
     if (!BadPtr(aconn->host) && !BadPtr(aconn->name))
     {
-  if ((s = strchr(aconn->host, '@')))
-      s++;
-  else
-      s = aconn->host;
+	if ((s = strchr(aconn->host, '@')))
+	    s++;
+	else
+	    s = aconn->host;
 
-  /*
-   * Prepare structure in case we have to wait for a reply which
-   * we get later and store away.
-   */
-  ln.value.aconn = aconn;
-  ln.flags = ASYNC_CONF;
+	/*
+	 * Prepare structure in case we have to wait for a reply which
+	 * we get later and store away.
+	 */
+	ln.value.aconn = aconn;
+	ln.flags = ASYNC_CONF;
 
-  if (inet_pton(AF_INET, s, &aconn->ipnum.ip4) == 1)
-      aconn->ipnum_family = AF_INET;
-  else if (inet_pton(AF_INET6, s, &aconn->ipnum.ip6) == 1)
-      aconn->ipnum_family = AF_INET6;
-  else if (IsAlpha(*s))
-  {
-      union
-      {
-  struct sockaddr_in ip4;
-  struct sockaddr_in6 ip6;
-      } tmp_addr;
-      int family;
+	if (inet_pton(AF_INET, s, &aconn->ipnum.ip4) == 1)
+	    aconn->ipnum_family = AF_INET;
+	else if (inet_pton(AF_INET6, s, &aconn->ipnum.ip6) == 1)
+	    aconn->ipnum_family = AF_INET6;
+	else if (IsAlpha(*s))
+	{
+	    union
+	    {
+		struct sockaddr_in ip4;
+		struct sockaddr_in6 ip6;
+	    } tmp_addr;
+	    int family;
 
-      /* Try to use the same address family as what we bind to. */
-      if (aconn->source &&
-  inet_pton(AF_INET, aconn->source, &tmp_addr.ip4) == 1)
-  family = AF_INET;
-      else if (aconn->source &&
-       inet_pton(AF_INET6, aconn->source, &tmp_addr.ip6) == 1)
-  family = AF_INET6;
-      else
-  family = AF_INET;
+	    /* Try to use the same address family as what we bind to. */
+	    if (aconn->source &&
+		inet_pton(AF_INET, aconn->source, &tmp_addr.ip4) == 1)
+		family = AF_INET;
+	    else if (aconn->source &&
+		     inet_pton(AF_INET6, aconn->source, &tmp_addr.ip6) == 1)
+		family = AF_INET6;
+	    else
+		family = AF_INET;
 
-      if ((hp = gethost_byname(s, &ln, family)))
-      {
-  aconn->ipnum_family = hp->h_addrtype;
-  memcpy((char *) &aconn->ipnum, hp->h_addr, hp->h_length);
-      }
-  }
+	    if ((hp = gethost_byname(s, &ln, family)))
+	    {
+		aconn->ipnum_family = hp->h_addrtype;
+		memcpy((char *) &aconn->ipnum, hp->h_addr, hp->h_length);
+	    }
+	}
     }
 
     Debug((DEBUG_ERROR, "Host/server name error: (%s) (%s)",
-     aconn->host, aconn->name));
+	   aconn->host, aconn->name));
     return -1;
 }
 

--- a/src/s_conf.c
+++ b/src/s_conf.c
@@ -383,6 +383,7 @@ find_oper(char *name, char *username, char *sockhost, char *hostip)
     char userhost[USERLEN + HOSTLEN + 3];
     char userip[USERLEN + HOSTLEN + 3];
     int i;
+    int nickmatch;
 
     /* sockhost OR hostip must match our host field */
 
@@ -397,39 +398,41 @@ find_oper(char *name, char *username, char *sockhost, char *hostip)
 
         for(i = 0; aoper->hosts[i]; i++)
         {
-            if(!mycmp(name, aoper->nick) && (!match(aoper->hosts[i], userhost)
+            if(!mycmp(name, aoper->nick))
+                nickmatch=1;
+            if(nickmatch && (!match(aoper->hosts[i], userhost)
                     || !match(aoper->hosts[i], userip)))
                 return aoper;
-	    if(strchr(aoper->hosts[i], '/'))
-	    {
-		char cidrbuf[USERLEN + HOSTLEN + 3];
-		char ipbuf1[16], ipbuf2[16];
-		char *s;
-		int bits;
-		int family;
+            if(strchr(aoper->hosts[i], '/'))
+            {
+                char cidrbuf[USERLEN + HOSTLEN + 3];
+                char ipbuf1[16], ipbuf2[16];
+                char *s;
+                int bits;
+                int family;
 
-		s = strchr(aoper->hosts[i], '@');
-		if (s)
-		    s++;
-		else
-		    s = aoper->hosts[i];
+                s = strchr(aoper->hosts[i], '@');
+                if (s)
+                    s++;
+                else
+                    s = aoper->hosts[i];
 
-		if (inet_pton(AF_INET, hostip, ipbuf1) == 1)
-		    family = AF_INET;
-		else if (inet_pton(AF_INET6, hostip, ipbuf1) == 1)
-		    family = AF_INET6;
-		else
-		    family = 0;
+                if (inet_pton(AF_INET, hostip, ipbuf1) == 1)
+                    family = AF_INET;
+                else if (inet_pton(AF_INET6, hostip, ipbuf1) == 1)
+                    family = AF_INET6;
+                else
+                    family = 0;
 
-		bits = inet_parse_cidr(family, s, ipbuf2, sizeof(ipbuf2));
-		if (bits > 0 && bitncmp(ipbuf1, ipbuf2, bits) == 0)
-		{
-		    /* Check the wildcards in the rest of the string. */
-		    ircsprintf(cidrbuf, "%s@%s", username, s);
-		    if (match(aoper->hosts[i], cidrbuf) == 0)
-			return aoper;
-		}
-	    }
+                bits = inet_parse_cidr(family, s, ipbuf2, sizeof(ipbuf2));
+                if (bits > 0 && bitncmp(ipbuf1, ipbuf2, bits) == 0)
+                {
+                    /* Check the wildcards in the rest of the string. */
+                    ircsprintf(cidrbuf, "%s@%s", username, s);
+                    if (!match(aoper->hosts[i], cidrbuf) && nickmatch)
+                        return aoper;
+                }
+            }
         }
     }
     return NULL;
@@ -490,7 +493,7 @@ set_effective_class(aClient *cptr)
     cptr->class->links++;
     return;
 }
-    
+
 
 /* find the first (best) I line to attach.
  * rewritten in feb04 for the overdue death of aConfItem
@@ -498,7 +501,7 @@ set_effective_class(aClient *cptr)
  * Rewritten again in Mar04 to optimize and get rid of deceptive logic.
  * Whoever wrote this originally must have been drunk...  -Quension
  */
-int 
+int
 attach_Iline(aClient *cptr, struct hostent *hp, char *sockhost)
 {
     aAllow *allow;
@@ -522,7 +525,7 @@ attach_Iline(aClient *cptr, struct hostent *hp, char *sockhost)
         add_local_domain(namehost, len - strlen(namehost));
     }
 
-    for (allow = allows; allow; allow = allow->next) 
+    for (allow = allows; allow; allow = allow->next)
     {
         if(allow->legal == -1)
             continue;
@@ -558,44 +561,44 @@ attach_Iline(aClient *cptr, struct hostent *hp, char *sockhost)
             {
                 if (!match(allow->ipmask, useriphost))
                     return (attach_iline(cptr, allow, iphost, 1));
-		else if (strchr(allow->ipmask, '/'))
-		{
-		    char cidrbuf[USERLEN + 1 + HOSTLEN + 1];
-		    char ipbuf[16];
-		    char *s;
-		    int bits;
+  else if (strchr(allow->ipmask, '/'))
+  {
+      char cidrbuf[USERLEN + 1 + HOSTLEN + 1];
+      char ipbuf[16];
+      char *s;
+      int bits;
 
-		    s = strchr(allow->ipmask, '@');
-		    if (s)
-			s++;
-		    else
-			continue;
+      s = strchr(allow->ipmask, '@');
+      if (s)
+  s++;
+      else
+  continue;
 
-		    bits = inet_parse_cidr(cptr->ip_family, s,
-					   ipbuf, sizeof(ipbuf));
-		    if (bits > 0 && bitncmp(&cptr->ip, ipbuf, bits) == 0)
-		    {
-			/* Check the wildcards in the rest of the string. */
-			ircsprintf(cidrbuf, "%s@%s", cptr->username, s);
-			if (match(allow->ipmask, cidrbuf) == 0)
-			    return (attach_iline(cptr, allow, iphost, 1));
-		    }
-		}
+      bits = inet_parse_cidr(cptr->ip_family, s,
+     ipbuf, sizeof(ipbuf));
+      if (bits > 0 && bitncmp(&cptr->ip, ipbuf, bits) == 0)
+      {
+  /* Check the wildcards in the rest of the string. */
+  ircsprintf(cidrbuf, "%s@%s", cptr->username, s);
+  if (match(allow->ipmask, cidrbuf) == 0)
+      return (attach_iline(cptr, allow, iphost, 1));
+      }
+  }
             }
             else
             {
                 if (!match(allow->ipmask, iphost))
                     return (attach_iline(cptr, allow, iphost, 0));
-		else if (strchr(allow->ipmask, '/'))
-		{
-		    char ipbuf[16];
-		    int bits;
+  else if (strchr(allow->ipmask, '/'))
+  {
+      char ipbuf[16];
+      int bits;
 
-		    bits = inet_parse_cidr(cptr->ip_family, allow->ipmask,
-					   ipbuf, sizeof(ipbuf));
-		    if (bits > 0 && bitncmp(&cptr->ip, ipbuf, bits) == 0)
-			return (attach_iline(cptr, allow, iphost, 1));
-		}
+      bits = inet_parse_cidr(cptr->ip_family, allow->ipmask,
+     ipbuf, sizeof(ipbuf));
+      if (bits > 0 && bitncmp(&cptr->ip, ipbuf, bits) == 0)
+  return (attach_iline(cptr, allow, iphost, 1));
+  }
             }
         }
     }
@@ -606,7 +609,7 @@ attach_Iline(aClient *cptr, struct hostent *hp, char *sockhost)
  * rewrote to remove the "ONE" lamity *BLEH* I agree with comstud on
  * this one. - Dianora
  */
-static int 
+static int
 attach_iline(aClient *cptr, aAllow *allow, char *uhost, int doid)
 {
     if(allow->class->links >= allow->class->maxlinks)
@@ -615,7 +618,7 @@ attach_iline(aClient *cptr, aAllow *allow, char *uhost, int doid)
     if (doid)
         cptr->flags |= FLAGS_DOID;
     get_sockhost(cptr, uhost);
-    
+
     cptr->user->allow = allow;
     allow->clients++;
 
@@ -953,45 +956,45 @@ confadd_connect(cVar *vars[], int lnum)
 
     if(x->source)
     {
-	union
-	{
-	    struct sockaddr_in ip4;
-	    struct sockaddr_in6 ip6;
-	} tmp_addr;
-	int host_family, source_family;
-	const char *s;
+  union
+  {
+      struct sockaddr_in ip4;
+      struct sockaddr_in6 ip6;
+  } tmp_addr;
+  int host_family, source_family;
+  const char *s;
 
-	s = strchr(x->host, '@');
-	if (s)
-	    s++;
-	else
-	    s = x->host;
+  s = strchr(x->host, '@');
+  if (s)
+      s++;
+  else
+      s = x->host;
 
-	if (inet_pton(AF_INET, s, &tmp_addr.ip4) == 1)
-	    host_family = AF_INET;
-	else if (inet_pton(AF_INET6, s, &tmp_addr.ip6) == 1)
-	    host_family = AF_INET6;
-	else
-	    host_family = 0;
+  if (inet_pton(AF_INET, s, &tmp_addr.ip4) == 1)
+      host_family = AF_INET;
+  else if (inet_pton(AF_INET6, s, &tmp_addr.ip6) == 1)
+      host_family = AF_INET6;
+  else
+      host_family = 0;
 
-	if (inet_pton(AF_INET, x->source, &tmp_addr.ip4) == 1)
-	    source_family = AF_INET;
-	else if (inet_pton(AF_INET6, x->source, &tmp_addr.ip6) == 1)
-	    source_family = AF_INET6;
-	else
-	{
-	    confparse_error("Invalid source address in connect block", lnum);
-	    free_connect(x);
-	    return -1;
-	}
+  if (inet_pton(AF_INET, x->source, &tmp_addr.ip4) == 1)
+      source_family = AF_INET;
+  else if (inet_pton(AF_INET6, x->source, &tmp_addr.ip6) == 1)
+      source_family = AF_INET6;
+  else
+  {
+      confparse_error("Invalid source address in connect block", lnum);
+      free_connect(x);
+      return -1;
+  }
 
-	if (host_family != 0 && host_family != source_family)
-	{
-	    confparse_error("Address family of host does not match "
-			    "address family of source in connect block", lnum);
-	    free_connect(x);
-	    return -1;
-	}
+  if (host_family != 0 && host_family != source_family)
+  {
+      confparse_error("Address family of host does not match "
+      "address family of source in connect block", lnum);
+      free_connect(x);
+      return -1;
+  }
     }
     x->next = new_connects;
     new_connects = x;
@@ -1144,8 +1147,8 @@ confadd_options(cVar *vars[], int lnum)
             tmp->type = NULL;
             tswarndelta = atoi(tmp->value);
         }
-	else if(tmp->type && (tmp->type->flag & OPTF_REMREHOK))
-	{
+  else if(tmp->type && (tmp->type->flag & OPTF_REMREHOK))
+  {
             tmp->type = NULL;
             new_confopts |= FLAGS_REMREHOK;
         }
@@ -1814,7 +1817,7 @@ confadd_modules(cVar *vars[], int lnum)
     }
     return lnum;
 }
-    
+
 
 /* set_classes
  * after loading the config into temporary lists, we must
@@ -1845,7 +1848,7 @@ set_classes(void)
      * You may be wondering why we're doing this here and appearently
      * again in our merge routines!  well, this is for sanity.  if
      * for whatever reason we dont have a class for each definition here,
-     * back out of the conf load immediately and we wont have distroyed 
+     * back out of the conf load immediately and we wont have distroyed
      * or overwritten any of our active data.
      * After we run our merge_classes() routine at the start of our
      * merge, then some of these classes will update currently active
@@ -2062,7 +2065,7 @@ merge_allows()
     }
     return;     /* this one is easy */
 }
-    
+
 static void
 merge_opers()
 {
@@ -2135,7 +2138,7 @@ static void
 merge_ports()
 {
     aPort *aport, *old_port, *ptrn;
-    
+
     if(forked)
         close_listeners();      /* marks ports for deletion */
 
@@ -2334,7 +2337,7 @@ clear_newconfs()
 
 /*
  * rehash
- * 
+ *
  * Actual REHASH service routine. Called with sig == 0 if it has been
  * called as a result of an operator issuing this command, else assume
  * it has been called as a result of the server receiving a HUP signal.
@@ -2345,25 +2348,25 @@ int rehash(aClient *cptr, aClient *sptr, int sig)
     int         i;
     char       *conferr;
 
-    if (sig == SIGHUP) 
+    if (sig == SIGHUP)
     {
 #ifdef USE_SSL
-		/* Rehash SSL so we can automate certificate renewals and updates externally, i.e. from a cron job --xPsycho */
-		sendto_ops("Got signal SIGHUP, rehashing SSL");
-		ssl_rehash();
+  /* Rehash SSL so we can automate certificate renewals and updates externally, i.e. from a cron job --xPsycho */
+  sendto_ops("Got signal SIGHUP, rehashing SSL");
+  ssl_rehash();
 #endif
         sendto_ops("Got signal SIGHUP, reloading ircd conf. file");
         remove_userbans_match_flags(UBAN_NETWORK, 0);
         /* remove all but kill {} blocks from conf */
         remove_userbans_match_flags(UBAN_LOCAL, UBAN_CONF);
-	remove_simbans_match_flags(SBAN_NICK|SBAN_LOCAL|SBAN_TEMPORARY, SBAN_SVSHOLD);
+  remove_simbans_match_flags(SBAN_NICK|SBAN_LOCAL|SBAN_TEMPORARY, SBAN_SVSHOLD);
         remove_simbans_match_flags(SBAN_CHAN|SBAN_LOCAL|SBAN_TEMPORARY, 0);
         remove_simbans_match_flags(SBAN_GCOS|SBAN_LOCAL|SBAN_TEMPORARY, 0);
         throttle_rehash();
     }
 
     for (i = 0; i <= highest_fd; i++)
-        if ((acptr = local[i]) && !IsMe(acptr)) 
+        if ((acptr = local[i]) && !IsMe(acptr))
         {
             /*
              * Nullify any references from client structures to this host
@@ -2408,7 +2411,7 @@ int rehash(aClient *cptr, aClient *sptr, int sig)
         clear_newconfs();
         return 1;
     }
-    
+
     merge_confs();
     build_rplcache();
     nextconnect = 1;    /* reset autoconnects */
@@ -2440,51 +2443,51 @@ static int lookup_confhost(aConnect *aconn)
      */
     if (!BadPtr(aconn->host) && !BadPtr(aconn->name))
     {
-	if ((s = strchr(aconn->host, '@')))
-	    s++;
-	else
-	    s = aconn->host;
+  if ((s = strchr(aconn->host, '@')))
+      s++;
+  else
+      s = aconn->host;
 
-	/*
-	 * Prepare structure in case we have to wait for a reply which
-	 * we get later and store away.
-	 */
-	ln.value.aconn = aconn;
-	ln.flags = ASYNC_CONF;
+  /*
+   * Prepare structure in case we have to wait for a reply which
+   * we get later and store away.
+   */
+  ln.value.aconn = aconn;
+  ln.flags = ASYNC_CONF;
 
-	if (inet_pton(AF_INET, s, &aconn->ipnum.ip4) == 1)
-	    aconn->ipnum_family = AF_INET;
-	else if (inet_pton(AF_INET6, s, &aconn->ipnum.ip6) == 1)
-	    aconn->ipnum_family = AF_INET6;
-	else if (IsAlpha(*s))
-	{
-	    union
-	    {
-		struct sockaddr_in ip4;
-		struct sockaddr_in6 ip6;
-	    } tmp_addr;
-	    int family;
+  if (inet_pton(AF_INET, s, &aconn->ipnum.ip4) == 1)
+      aconn->ipnum_family = AF_INET;
+  else if (inet_pton(AF_INET6, s, &aconn->ipnum.ip6) == 1)
+      aconn->ipnum_family = AF_INET6;
+  else if (IsAlpha(*s))
+  {
+      union
+      {
+  struct sockaddr_in ip4;
+  struct sockaddr_in6 ip6;
+      } tmp_addr;
+      int family;
 
-	    /* Try to use the same address family as what we bind to. */
-	    if (aconn->source &&
-		inet_pton(AF_INET, aconn->source, &tmp_addr.ip4) == 1)
-		family = AF_INET;
-	    else if (aconn->source &&
-		     inet_pton(AF_INET6, aconn->source, &tmp_addr.ip6) == 1)
-		family = AF_INET6;
-	    else
-		family = AF_INET;
+      /* Try to use the same address family as what we bind to. */
+      if (aconn->source &&
+  inet_pton(AF_INET, aconn->source, &tmp_addr.ip4) == 1)
+  family = AF_INET;
+      else if (aconn->source &&
+       inet_pton(AF_INET6, aconn->source, &tmp_addr.ip6) == 1)
+  family = AF_INET6;
+      else
+  family = AF_INET;
 
-	    if ((hp = gethost_byname(s, &ln, family)))
-	    {
-		aconn->ipnum_family = hp->h_addrtype;
-		memcpy((char *) &aconn->ipnum, hp->h_addr, hp->h_length);
-	    }
-	}
+      if ((hp = gethost_byname(s, &ln, family)))
+      {
+  aconn->ipnum_family = hp->h_addrtype;
+  memcpy((char *) &aconn->ipnum, hp->h_addr, hp->h_length);
+      }
+  }
     }
 
     Debug((DEBUG_ERROR, "Host/server name error: (%s) (%s)",
-	   aconn->host, aconn->name));
+     aconn->host, aconn->name));
     return -1;
 }
 
@@ -2703,4 +2706,3 @@ memcount_s_conf(MCs_conf *mc)
 
     return mc->total.m;
 }
-

--- a/src/s_user.c
+++ b/src/s_user.c
@@ -3358,14 +3358,20 @@ m_umode(aClient *cptr, aClient *sptr, int parc, char *parv[])
                 case 'X':
                 case 'S':
                     break; /* users can't set themselves +r,+x,+X or +S! */
+#ifdef USER_HOSTMASKING
                 case 'H':
                     // Ensure hostmasking settings are enabled to allow setting the mode.
-                    // Do not allow opers who are already oper hostmasked to set the mode.
-                    if(((uhm_type > 0) && (uhm_umodeh > 0) && (strcasecmp(sptr->sockhost, Staff_Address) != 0) && (what == MODE_ADD))
-                            || (what == MODE_DEL))
+                    if(((uhm_type > 0) && (uhm_umodeh > 0) && (what == MODE_ADD)) || (what == MODE_DEL))
                     {
                         if(MyClient(sptr))
                         {
+                            // Do not allow opers who are already oper hostmasked to set the mode.
+                            if(strcasecmp(sptr->user->mhost, Staff_Address) == 0) {
+                                sendto_one(sptr, ":%s NOTICE %s :*** Notice -- You cannot set user mode H since you are already oper hostmasked.",
+                                           me.name, sptr->name);
+                                break;
+                            }
+
                             // Do not allow the mode change if the user is in any channels.  This is to prevent potential client-side
                             // weirdness from happening if a user's host changes while they're already in one or more channels.
                             if(sptr->user->channel != NULL)
@@ -3407,6 +3413,7 @@ m_umode(aClient *cptr, aClient *sptr, int parc, char *parv[])
                         }
                     }
                     break;
+#endif
                 case 'A':
                     /* set auto +a if user is setting +A */
                     if (MyClient(sptr) && (what == MODE_ADD))


### PR DESCRIPTION
find_oper() logic now checks for nick before iterating through host list and takes nick match into consideration when deciding to return aoper pointer when CIDR matches.