### PR TITLE
Fix xflag problem

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,10 +8,11 @@ Ryan Smith(2):
      Override clone limits with SVSCLONE (PR #148)
      Updates to user hostmasking (PR #175)
 
-Emilio Escobar(3):
+Emilio Escobar(4):
      Fixed oper block corruption when two opers share the same IP (PR #181)
      Override softlimits with SVSCLONE (PR #162)
      Decrease unknown count if cptr is in unknown state (PR #160)
+     Enable channel half ops (PR #184)
 
 Kobi Shmueli(1):
      Change user hostmask to send user's IP (PR #179)

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,27 @@
+Changes for 2.2.0:
+------------------
+rasengan(2):
+     Search for WEBIRC users using /rwho (PR #139)
+     Added /stats P to show listening ports (PR #134)
+
+Ryan Smith(2):
+     Override clone limits with SVSCLONE (PR #148)
+     Updates to user hostmasking (PR #175)
+
+Emilio Escobar(3):
+     Fixed oper block corruption when two opers share the same IP (PR #181)
+     Override softlimits with SVSCLONE (PR #162)
+     Decrease unknown count if cptr is in unknown state (PR #160)
+
+Kobi Shmueli(1):
+     Change user hostmask to send user's IP (PR #179)
+
+Ned T. Crigler(1):
+     Make configure test support for extra compiler flags (PR #167)
+
+jeian(1):
+     Add XFLAG documentation (PR #155)
+
 Changes for 2.1.6:
 ------------------
 Ryan Smith (4):

--- a/include/config.h
+++ b/include/config.h
@@ -906,7 +906,7 @@
 /*
  * Don't allow local clients to use +h/-h until all servers and services are upgraded.
  */
-#define NO_LOCAL_CMODE_h
+#undef NO_LOCAL_CMODE_h
 
 /* ------------------------- END CONFIGURATION SECTION -------------------- */
 #ifdef APOLLO

--- a/include/patchlevel.h
+++ b/include/patchlevel.h
@@ -21,8 +21,8 @@
 
 #define BASENAME "bahamut"
 #define MAJOR 2
-#define MINOR 1
-#define PATCH 6
+#define MINOR 2
+#define PATCH 0
 
 #define PATCHES ""
 

--- a/src/channel.c
+++ b/src/channel.c
@@ -1350,7 +1350,7 @@ int verbose_to_relaychan(aClient *sptr, aChannel *chptr, char *cmd, char *reason
 }
 
 /* A function to send a (verbose) message to +f opers */
-inline void verbose_to_opers(aClient *sptr, aChannel *chptr, char *cmd, char *reason)
+void verbose_to_opers(aClient *sptr, aChannel *chptr, char *cmd, char *reason)
 {
     if(call_hooks(CHOOK_FLOODWARN, sptr, chptr, 1, cmd, reason) == FLUSH_BUFFER) return;
 

--- a/src/m_nick.c
+++ b/src/m_nick.c
@@ -40,7 +40,7 @@ extern int del_dccallow(aClient *, aClient *, int);
 
 extern int is_xflags_exempted(aClient *sptr, aChannel *chptr);
 extern int verbose_to_relaychan(aClient *sptr, aChannel *chptr, char *cmd, char *reason);
-extern inline void verbose_to_opers(aClient *sptr, aChannel *chptr, char *cmd, char *reason);
+extern void verbose_to_opers(aClient *sptr, aChannel *chptr, char *cmd, char *reason);
 
 extern int user_modes[];
 

--- a/src/s_user.c
+++ b/src/s_user.c
@@ -59,7 +59,7 @@ extern int send_lusers(aClient *,aClient *,int, char **);
 #endif
 extern int is_xflags_exempted(aClient *sptr, aChannel *chptr); /* for m_message() */
 extern int verbose_to_relaychan(aClient *sptr, aChannel *chptr, char *cmd, char *reason); /* for m_message() */
-extern inline void verbose_to_opers(aClient *sptr, aChannel *chptr, char *cmd, char *reason); /* for m_message() */
+extern void verbose_to_opers(aClient *sptr, aChannel *chptr, char *cmd, char *reason); /* for m_message() */
 extern time_t get_user_jointime(aClient *cptr, aChannel *chptr); /* for send_msg_error() */
 extern time_t get_user_lastmsgtime(aClient *cptr, aChannel *chptr); /* also for send_msg_error() -Holbrook */
 extern int server_was_split;


### PR DESCRIPTION
Fix compile errors in 2.20 branch

```
/usr/bin/ld: m_nick.o: in function `m_nick':
/home/rscs/dalnet/bahamut-dalnet-github/src/m_nick.c:498: undefined reference to `verbose_to_opers'
/usr/bin/ld: s_user.o: in function `m_quit':
/home/rscs/dalnet/bahamut-dalnet-github/src/s_user.c:2480: undefined reference to `verbose_to_opers'
/usr/bin/ld: s_user.o: in function `m_message':
/home/rscs/dalnet/bahamut-dalnet-github/src/s_user.c:1718: undefined reference to `verbose_to_opers'
/usr/bin/ld: /home/rscs/dalnet/bahamut-dalnet-github/src/s_user.c:1698: undefined reference to `verbose_to_opers'
/usr/bin/ld: /home/rscs/dalnet/bahamut-dalnet-github/src/s_user.c:1707: undefined reference to `verbose_to_opers'
/usr/bin/ld: s_user.o:/home/rscs/dalnet/bahamut-dalnet-github/src/s_user.c:1766: more undefined references to `verbose_to_opers' follow
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:52: ircd] Error 1
```