### PR TITLE
Remove "inline" from verbose_to_opers to fix compile errors.

### DIFF
--- a/include/h.h
+++ b/include/h.h
@@ -260,6 +260,7 @@ extern int  	  do_numeric(int, aClient *, aClient *, int, char **);
 extern int  	  hunt_server(aClient *, aClient *, char *, int, int, char **);
 extern aClient 	 *next_client(aClient *, char *);
 extern aClient 	 *next_client_double(aClient *, char *);
+extern inline void verbose_to_opers(aClient *sptr, aChannel *chptr, char *cmd, char *reason); /* for m_message() */
 
 extern int  	  m_umode(aClient *, aClient *, int, char **);
 extern int  	  m_names(aClient *, aClient *, int, char **);

--- a/src/channel.c
+++ b/src/channel.c
@@ -1350,7 +1350,7 @@ int verbose_to_relaychan(aClient *sptr, aChannel *chptr, char *cmd, char *reason
 }
 
 /* A function to send a (verbose) message to +f opers */
-void verbose_to_opers(aClient *sptr, aChannel *chptr, char *cmd, char *reason)
+inline void verbose_to_opers(aClient *sptr, aChannel *chptr, char *cmd, char *reason)
 {
     if(call_hooks(CHOOK_FLOODWARN, sptr, chptr, 1, cmd, reason) == FLUSH_BUFFER) return;
 

--- a/src/channel.c
+++ b/src/channel.c
@@ -1350,7 +1350,7 @@ int verbose_to_relaychan(aClient *sptr, aChannel *chptr, char *cmd, char *reason
 }
 
 /* A function to send a (verbose) message to +f opers */
-inline void verbose_to_opers(aClient *sptr, aChannel *chptr, char *cmd, char *reason)
+void verbose_to_opers(aClient *sptr, aChannel *chptr, char *cmd, char *reason)
 {
     if(call_hooks(CHOOK_FLOODWARN, sptr, chptr, 1, cmd, reason) == FLUSH_BUFFER) return;
 

--- a/src/m_nick.c
+++ b/src/m_nick.c
@@ -32,7 +32,7 @@
 #include "userban.h"
 #include "hooks.h"
 
-extern int do_user(char *, aClient *, aClient *, char *, char *, char *,
+extern inline int do_user(char *, aClient *, aClient *, char *, char *, char *,
 		   unsigned long, char *, char *);
 
 extern int register_user(aClient *, aClient *, char *, char *, char *);
@@ -40,7 +40,6 @@ extern int del_dccallow(aClient *, aClient *, int);
 
 extern int is_xflags_exempted(aClient *sptr, aChannel *chptr);
 extern int verbose_to_relaychan(aClient *sptr, aChannel *chptr, char *cmd, char *reason);
-extern void verbose_to_opers(aClient *sptr, aChannel *chptr, char *cmd, char *reason);
 
 extern int user_modes[];
 

--- a/src/m_nick.c
+++ b/src/m_nick.c
@@ -32,7 +32,7 @@
 #include "userban.h"
 #include "hooks.h"
 
-extern inline int do_user(char *, aClient *, aClient *, char *, char *, char *,
+extern int do_user(char *, aClient *, aClient *, char *, char *, char *,
 		   unsigned long, char *, char *);
 
 extern int register_user(aClient *, aClient *, char *, char *, char *);

--- a/src/m_nick.c
+++ b/src/m_nick.c
@@ -40,7 +40,7 @@ extern int del_dccallow(aClient *, aClient *, int);
 
 extern int is_xflags_exempted(aClient *sptr, aChannel *chptr);
 extern int verbose_to_relaychan(aClient *sptr, aChannel *chptr, char *cmd, char *reason);
-extern inline void verbose_to_opers(aClient *sptr, aChannel *chptr, char *cmd, char *reason);
+extern void verbose_to_opers(aClient *sptr, aChannel *chptr, char *cmd, char *reason);
 
 extern int user_modes[];
 

--- a/src/s_user.c
+++ b/src/s_user.c
@@ -59,7 +59,7 @@ extern int send_lusers(aClient *,aClient *,int, char **);
 #endif
 extern int is_xflags_exempted(aClient *sptr, aChannel *chptr); /* for m_message() */
 extern int verbose_to_relaychan(aClient *sptr, aChannel *chptr, char *cmd, char *reason); /* for m_message() */
-extern inline void verbose_to_opers(aClient *sptr, aChannel *chptr, char *cmd, char *reason); /* for m_message() */
+extern void verbose_to_opers(aClient *sptr, aChannel *chptr, char *cmd, char *reason); /* for m_message() */
 extern time_t get_user_jointime(aClient *cptr, aChannel *chptr); /* for send_msg_error() */
 extern time_t get_user_lastmsgtime(aClient *cptr, aChannel *chptr); /* also for send_msg_error() -Holbrook */
 extern int server_was_split;

--- a/src/s_user.c
+++ b/src/s_user.c
@@ -59,7 +59,6 @@ extern int send_lusers(aClient *,aClient *,int, char **);
 #endif
 extern int is_xflags_exempted(aClient *sptr, aChannel *chptr); /* for m_message() */
 extern int verbose_to_relaychan(aClient *sptr, aChannel *chptr, char *cmd, char *reason); /* for m_message() */
-extern void verbose_to_opers(aClient *sptr, aChannel *chptr, char *cmd, char *reason); /* for m_message() */
 extern time_t get_user_jointime(aClient *cptr, aChannel *chptr); /* for send_msg_error() */
 extern time_t get_user_lastmsgtime(aClient *cptr, aChannel *chptr); /* also for send_msg_error() -Holbrook */
 extern int server_was_split;


### PR DESCRIPTION
```
/usr/bin/ld: m_nick.o: in function `m_nick':
/home/rscs/dalnet/bahamut-dalnet-github/src/m_nick.c:498: undefined reference to `verbose_to_opers'
/usr/bin/ld: s_user.o: in function `m_quit':
/home/rscs/dalnet/bahamut-dalnet-github/src/s_user.c:2480: undefined reference to `verbose_to_opers'
/usr/bin/ld: s_user.o: in function `m_message':
/home/rscs/dalnet/bahamut-dalnet-github/src/s_user.c:1718: undefined reference to `verbose_to_opers'
/usr/bin/ld: /home/rscs/dalnet/bahamut-dalnet-github/src/s_user.c:1698: undefined reference to `verbose_to_opers'
/usr/bin/ld: /home/rscs/dalnet/bahamut-dalnet-github/src/s_user.c:1707: undefined reference to `verbose_to_opers'
/usr/bin/ld: s_user.o:/home/rscs/dalnet/bahamut-dalnet-github/src/s_user.c:1766: more undefined references to `verbose_to_opers' follow
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:52: ircd] Error 1
```