### PR TITLE
Show UHM variables in /INFO.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,7 @@ rasengan (2):
      Search for WEBIRC users using /rwho (PR #139)
      Added /stats P to show listening ports (PR #134)
 
-Ryan Smith (8):
+Ryan Smith (9):
      Override clone limits with SVSCLONE (PR #148)
      Updates to user hostmasking (PR #175)
      Do not attempt to mask the Staff_Address for opers. (PR #175)
@@ -13,6 +13,7 @@ Ryan Smith (8):
      Do not allow user mode H to be changed if the user is in any channels. This is to prevent potential client-side weirdness from happening if a user's host changes while they're already in one or more channels. (PR #175)
      Send out WATCH notifications if the hostname changes due to a mode H change. (PR #175)
      Minor typo fixes.
+     Show UHM variables in /INFO.
 
 Emilio Escobar (4):
      Fixed oper block corruption when two opers share the same IP (PR #181)

--- a/src/s_serv.c
+++ b/src/s_serv.c
@@ -57,6 +57,8 @@
 static char buf[BUFSIZE];
 extern int  rehashed;
 extern int  forked;
+extern int uhm_type;
+extern int uhm_umodeh;
 
 /* external variables */
 
@@ -448,14 +450,14 @@ m_info(aClient *cptr, aClient *sptr, int parc, char *parv[])
             sendto_one(sptr, ":%s %d %s :zlib version: %s", me.name,
                        RPL_INFO, parv[0], ZLIB_VERSION);
             sendto_one(sptr, ":%s %d %s :FD_SETSIZE=%d WRITEV_IOV=%d "
-                       "MAXCONNECTIONS=%d MAX_BUFFER=%d MAXCLIENTS=%d",
+                             "MAXCONNECTIONS=%d MAX_BUFFER=%d MAXCLIENTS=%d uhm_type=%d uhm_umodeh=%d",
                        me.name, RPL_INFO, parv[0], FD_SETSIZE,
 #ifdef WRITEV_IOV
                        WRITEV_IOV,
 #else
                        0,
 #endif
-                       MAXCONNECTIONS, MAX_BUFFER, MAXCLIENTS);
+                       MAXCONNECTIONS, MAX_BUFFER, MAXCLIENTS, uhm_type, uhm_umodeh);
         }
 
         sendto_one(sptr, rpl_str(RPL_INFO), me.name, parv[0], "");


### PR DESCRIPTION
Show UHM variables in /INFO so we can check remotely what setting a server is on.