### PR TITLE
/who and /rwho fixes for hostmasking

### DIFF
--- a/src/m_rwho.c
+++ b/src/m_rwho.c
@@ -994,7 +994,7 @@ static int rwho_match(aClient *cptr, int *failcode, aClient **failclient)
         return 0;
 
     if ((rwho_opts.check[1] & RWM_HOST) &&
-        !rwho_opts.host_func[1](rwho_opts.host_pat[1], cptr->user->host) && !rwho_opts.host_func[1](rwho_opts.host_pat[1], cptr->user->mhost))
+        !rwho_opts.host_func[1](rwho_opts.host_pat[1], cptr->user->host) || !rwho_opts.host_func[1](rwho_opts.host_pat[1], cptr->user->mhost))
         return 0;
 
 #ifdef RWHO_PROBABILITY

--- a/src/m_rwho.c
+++ b/src/m_rwho.c
@@ -989,6 +989,7 @@ static int rwho_match(aClient *cptr, int *failcode, aClient **failclient)
 	    return 0;
     }
 
+#ifdef USER_HOSTMASKING
     if ((rwho_opts.check[0] & RWM_HOST) &&
         rwho_opts.host_func[0](rwho_opts.host_pat[0], cptr->user->host) && rwho_opts.host_func[0](rwho_opts.host_pat[0], cptr->user->mhost))
         return 0;
@@ -996,6 +997,15 @@ static int rwho_match(aClient *cptr, int *failcode, aClient **failclient)
     if ((rwho_opts.check[1] & RWM_HOST) &&
         !rwho_opts.host_func[1](rwho_opts.host_pat[1], cptr->user->host) || !rwho_opts.host_func[1](rwho_opts.host_pat[1], cptr->user->mhost))
         return 0;
+#else
+    if ((rwho_opts.check[0] & RWM_HOST) &&
+        rwho_opts.host_func[0](rwho_opts.host_pat[0], cptr->user->host))
+        return 0;
+
+    if ((rwho_opts.check[1] & RWM_HOST) &&
+        !rwho_opts.host_func[1](rwho_opts.host_pat[1], cptr->user->host))
+        return 0;
+#endif
 
 #ifdef RWHO_PROBABILITY
     if ((rwho_opts.check[0] | rwho_opts.check[1]) &

--- a/src/m_who.c
+++ b/src/m_who.c
@@ -655,11 +655,6 @@ int chk_who(aClient *ac, aClient *sptr, int showall)
 #endif
     }
     
-    if(wsopts.host!=NULL)
-	if((wsopts.host_plus && hchkfn(wsopts.host, ac->user->host)) ||
-	   (!wsopts.host_plus && !hchkfn(wsopts.host, ac->user->host)))
-	    return 0;
-
     if(wsopts.cidr_plus)
 	if(ac->ip_family != wsopts.cidr_family ||
 	   bitncmp(&ac->ip, &wsopts.cidr_ip, wsopts.cidr_bits) != 0)


### PR DESCRIPTION
- Remove the old /who host check code which does not honor hostmasking properly.  The block above this one replaces this old logic.
- Fix bug with /rwho -h not excluding hostmasked clients properly
- Wrap /rwho host checking logic in #ifdef USER_HOSTMASKING