### PR TITLE
Fix support for compiling on Ubuntu 22.04

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -9,7 +9,10 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: "${{ matrix.os }}"
+    strategy:
+      matrix:
+        os: ["ubuntu-20.04", "ubuntu-22.04"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -31,3 +31,5 @@ jobs:
       run: ./configure
     - name: make
       run: make
+    - name: check src/ircd was built
+      run: ls src/ircd

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -2,7 +2,6 @@ name: C/C++ CI
 
 on:
   push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/include/dh.h
+++ b/include/dh.h
@@ -45,6 +45,7 @@ struct session_info
 static BIGNUM *ircd_prime;
 static BIGNUM *ircd_generator;
 
+#undef hex_to_string /* Defined by OpenSSL >= 3.0 */
 static char *hex_to_string[256] =
 {
     "00", "01", "02", "03", "04", "05", "06", "07",


### PR DESCRIPTION
Hi,

I noticed build is broken on Ubuntu 22.04. This PR adds CI for this version in addition to 20.04 (GitHub is currently moving `ubuntu-latest`from 20.04 to 22.04, but this repo was not migrated yet).

There is an ugly fix that seems to be enough to fix compilation with OpenSSL 3 (#182), but now it seems there are a bunch of link issues with glibc:

```
2022-12-06T19:40:07.2675814Z /usr/bin/ld: res.o: in function `query_name':
2022-12-06T19:40:07.2676638Z /home/runner/work/bahamut/bahamut/src/res.c:622: undefined reference to `__res_mkquery'
2022-12-06T19:40:07.2677194Z /usr/bin/ld: res.o: in function `proc_answer':
2022-12-06T19:40:07.2839313Z /home/runner/work/bahamut/bahamut/src/res.c:870: undefined reference to `__dn_expand'
2022-12-06T19:40:07.2840548Z /usr/bin/ld: /home/runner/work/bahamut/bahamut/src/res.c:968: undefined reference to `__dn_expand'
2022-12-06T19:40:07.2841219Z make[1]: Leaving directory '/home/runner/work/bahamut/bahamut/src'
2022-12-06T19:40:07.2842219Z /usr/bin/ld: /home/runner/work/bahamut/bahamut/src/res.c:1138: undefined reference to `__dn_expand'
2022-12-06T19:40:07.2842517Z Building doc
2022-12-06T19:40:07.2843444Z /usr/bin/ld: /home/runner/work/bahamut/bahamut/src/res.c:1270: undefined reference to `__dn_expand'
```

and I can't figure how to resolve them

Feel free to pick up from this.