### PR TITLE
Fix USERHOST not to reveal the user's real hostname to IRC Operators

### DIFF
--- a/src/s_user.c
+++ b/src/s_user.c
@@ -3188,7 +3188,7 @@ m_userhost(aClient *cptr, aClient *sptr, int parc, char *parv[])
                               (acptr->user->away) ? '-' : '+',
                               acptr->user->username, 
 #ifdef USER_HOSTMASKING
-                              (IsUmodeH(acptr) && sptr!=acptr && !IsAnOper(sptr))?acptr->user->mhost:
+                              (IsUmodeH(acptr) && sptr!=acptr)?acptr->user->mhost:
 #endif
                               acptr->user->host);
         }


### PR DESCRIPTION
This is to prevent IRC clients like mIRC from banning the user's real hostname when the user's address is not in its IAL (internal address list) and it is using USERHOST to get the user's hostname.