### PR TITLE
Adding TLS support for server<>server connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 #
 !.gitignore
 Makefile
+ltmain.sh
 config.log
 config.guess
 config.sub

--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -571,6 +571,10 @@ connect {
 #     H   other server is a hub (allowed to link other servers)
 #     Z   compress the link traffic
 #     E   encrypt the link using RC4 with DH key exchange
+#     S   encrypt the link using TLS/SSL
+# 
+# Note: E and S flags are mutually exclusive - only one encryption method
+# can be used per server connection.
 # 
 # The class token specifies the connection class to use for the server
 # link.  If not specified, the default class is used; see the Class block

--- a/doc/template.conf
+++ b/doc/template.conf
@@ -115,6 +115,9 @@ connect {
     cpasswd     secret;     # We send this password to hub
     flags       H;          # It is a hub
     class       hub;        # Use hub class
+    # Note: For encryption, use either E (Diffie-Hellman) or S (TLS), not both
+    # flags       HE;      # Hub with Diffie-Hellman encryption
+    # flags       HS;      # Hub with TLS encryption
 };
 
 
@@ -134,4 +137,7 @@ connect {
     apasswd     secret;         # Password services sends
     cpasswd     secret;         # Same password
     class       services;
+    # Note: For encryption, use either E (Diffie-Hellman) or S (TLS), not both
+    # flags       E;      # Services with Diffie-Hellman encryption
+    # flags       S;      # Services with TLS encryption
 };

--- a/include/h.h
+++ b/include/h.h
@@ -387,7 +387,7 @@ int safe_ssl_read(aClient *, void *, int);
 int safe_ssl_write(aClient *, const void *, int);
 int safe_ssl_accept(aClient *, int);
 int ssl_smart_shutdown(SSL *);
-int safe_ssl_connect(aClient *, int);
+int safe_ssl_connect(aClient *);
 int ssl_verify_callback(int, X509_STORE_CTX *);
 #endif
 

--- a/include/h.h
+++ b/include/h.h
@@ -387,6 +387,8 @@ int safe_ssl_read(aClient *, void *, int);
 int safe_ssl_write(aClient *, const void *, int);
 int safe_ssl_accept(aClient *, int);
 int ssl_smart_shutdown(SSL *);
+int safe_ssl_connect(aClient *, int);
+int ssl_verify_callback(int, X509_STORE_CTX *);
 #endif
 
 

--- a/include/struct.h
+++ b/include/struct.h
@@ -253,6 +253,7 @@ typedef struct SServicesTag ServicesTag;
 #define CAPAB_NOQUIT  0x0040 /* noquit support */
 #endif
 #define CAPAB_NICKIPSTR 0x0080 /* Nick IP as a string support */
+#define CAPAB_DOTLS     0x0100 /* server supports TL encryption */
 
 
 #define SetDKEY(x)	((x)->capabilities |= CAPAB_DKEY)
@@ -260,6 +261,12 @@ typedef struct SServicesTag ServicesTag;
 /* N: line, flag E */
 #define SetWantDKEY(x) ((x)->capabilities |= CAPAB_DODKEY)
 #define WantDKEY(x)	((x)->capabilities & CAPAB_DODKEY) 
+
+/* N: line, flag S */
+#define SetTLS(x)    ((x)->capabilities |= CAPAB_DOTLS)
+#define CanDoTLS(x)  ((x)->capabilities & CAPAB_DOTLS)
+#define SetWantTLS(x) ((x)->capabilities |= CAPAB_DOTLS)
+#define WantTLS(x)    ((x)->capabilities & CAPAB_DOTLS)
 
 #define SetZipCapable(x) ((x)->capabilities |= CAPAB_ZIP)
 #define IsZipCapable(x)	((x)->capabilities & CAPAB_ZIP)

--- a/include/struct.h
+++ b/include/struct.h
@@ -53,6 +53,7 @@
 #include <openssl/rsa.h>       /* OpenSSL stuff */
 #include <openssl/crypto.h>
 #include <openssl/x509.h>
+#include <openssl/x509_vfy.h>
 #include <openssl/pem.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>

--- a/include/struct.h
+++ b/include/struct.h
@@ -53,6 +53,7 @@
 #include <openssl/rsa.h>       /* OpenSSL stuff */
 #include <openssl/crypto.h>
 #include <openssl/x509.h>
+#include <openssl/objects.h>
 #include <openssl/pem.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>

--- a/include/struct.h
+++ b/include/struct.h
@@ -253,7 +253,7 @@ typedef struct SServicesTag ServicesTag;
 #define CAPAB_NOQUIT  0x0040 /* noquit support */
 #endif
 #define CAPAB_NICKIPSTR 0x0080 /* Nick IP as a string support */
-#define CAPAB_DOTLS     0x0100 /* server supports TL encryption */
+#define CAPAB_DOTLS     0x0100 /* server supports TLS encryption */
 
 
 #define SetDKEY(x)	((x)->capabilities |= CAPAB_DKEY)

--- a/include/struct.h
+++ b/include/struct.h
@@ -53,7 +53,6 @@
 #include <openssl/rsa.h>       /* OpenSSL stuff */
 #include <openssl/crypto.h>
 #include <openssl/x509.h>
-#include <openssl/x509_vfy.h>
 #include <openssl/pem.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>

--- a/include/struct.h
+++ b/include/struct.h
@@ -692,6 +692,7 @@ typedef struct Whowas
 #define CONN_ZIP 	0x001	/* zippable    */
 #define CONN_DKEY	0x010	/* cryptable   */
 #define CONN_HUB	0x100	/* hubbable!   */
+#define CONN_TLS	0x200	/* tlsable!    */
 
 /* U:line flags in Server struct */
 

--- a/src/m_stats.c
+++ b/src/m_stats.c
@@ -314,7 +314,11 @@ serv_info(aClient *cptr, char *name)
         if(RC4EncLink(acptr))
             sendto_one(cptr, ":%s %d %s : - RC4 encrypted", me.name, 
                         RPL_STATSDEBUG, name);
-
+#ifdef USE_SSL
+        if(IsSSL(acptr))
+            sendto_one(cptr, ":%s %d %s : - TLS encrypted", me.name, 
+                        RPL_STATSDEBUG, name);
+#endif
         if(ZipOut(acptr))
         {
             unsigned long ib, ob;

--- a/src/s_bsd.c
+++ b/src/s_bsd.c
@@ -1982,7 +1982,6 @@ int connect_server(aConnect *aconn, aClient * by, struct hostent *hp)
 
         SetSSL(cptr);
         SSL_set_fd(cptr->ssl, cptr->fd);
-        int ret = 0;
 
         SSL_set_ex_data(cptr->ssl, mydata_index, aconn);
 

--- a/src/s_bsd.c
+++ b/src/s_bsd.c
@@ -1990,6 +1990,7 @@ int connect_server(aConnect *aconn, aClient * by, struct hostent *hp)
             sendto_realops_lev(DEBUG_LEV, "SSL_connect failed for %s", cptr->name);
             SSL_set_shutdown(cptr->ssl, SSL_RECEIVED_SHUTDOWN);
             ssl_smart_shutdown(cptr->ssl);
+            SSL_free(cptr->ssl);
             close(cptr->fd);
             cptr->fd = -2;
             free_client(cptr);

--- a/src/s_bsd.c
+++ b/src/s_bsd.c
@@ -1463,6 +1463,7 @@ aClient *add_connection(aListener *lptr, int fd)
             SSL_set_shutdown(acptr->ssl, SSL_RECEIVED_SHUTDOWN);
             ssl_smart_shutdown(acptr->ssl);
             SSL_free(acptr->ssl);
+            acptr->ssl = NULL;
             ircstp->is_ref++;
             acptr->fd = -2;
             free_client(acptr);
@@ -1991,6 +1992,7 @@ int connect_server(aConnect *aconn, aClient * by, struct hostent *hp)
             SSL_set_shutdown(cptr->ssl, SSL_RECEIVED_SHUTDOWN);
             ssl_smart_shutdown(cptr->ssl);
             SSL_free(cptr->ssl);
+            cptr->ssl = NULL;
             close(cptr->fd);
             cptr->fd = -2;
             free_client(cptr);

--- a/src/s_bsd.c
+++ b/src/s_bsd.c
@@ -865,7 +865,6 @@ int completed_connection(aClient * cptr)
     if (IsSSL(cptr) && cptr->ssl)
     {
         long verify_result = SSL_get_verify_result(cptr->ssl);
-        sendto_realops_lev(DEBUG_LEV, "SSL verification result: %ld [%s]", verify_result, cptr->name);
         
         switch (verify_result)
         {

--- a/src/s_bsd.c
+++ b/src/s_bsd.c
@@ -1991,8 +1991,8 @@ int connect_server(aConnect *aconn, aClient * by, struct hostent *hp)
             sendto_realops_lev(DEBUG_LEV, "SSL_connect failed for %s", cptr->name);
             SSL_set_shutdown(cptr->ssl, SSL_RECEIVED_SHUTDOWN);
             ssl_smart_shutdown(cptr->ssl);
-            cptr->fd = -2;
             close(cptr->fd);
+            cptr->fd = -2;
             free_client(cptr);
             return -1;
         }

--- a/src/s_bsd.c
+++ b/src/s_bsd.c
@@ -869,7 +869,7 @@ int completed_connection(aClient * cptr)
         
         switch (verify_result)
         {
-            case X509_V_SELF_SIGNED_CERT_IN_CHAIN:
+            case X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN:
             case X509_V_OK:
                 break;
             default:

--- a/src/s_bsd.c
+++ b/src/s_bsd.c
@@ -1966,7 +1966,7 @@ int connect_server(aConnect *aconn, aClient * by, struct hostent *hp)
     }
     
 #ifdef USE_SSL
-    if (aconn->flags & CONN_SSL)
+    if (aconn->flags & CONN_TLS)
     {
         extern SSL_CTX *server_ssl_ctx;
         cptr->ssl = NULL;

--- a/src/s_bsd.c
+++ b/src/s_bsd.c
@@ -895,9 +895,15 @@ int completed_connection(aClient * cptr)
 
     /* pass on our capabilities to the server we /connect'd */
 #ifdef HAVE_ENCRYPTION_ON
-    if(!(aconn->flags & CONN_DKEY) || (IsSSL(cptr) && cptr->ssl))
+    if(!(aconn->flags & CONN_DKEY) && !(aconn->flags & CONN_TLS))
+    {
         sendto_one(cptr, "CAPAB SSJOIN NOQUIT BURST UNCONNECT ZIP"
                          " NICKIP NICKIPSTR TSMODE");
+    } else if (aconn->flags & CONN_TLS)
+    {
+        sendto_one(cptr, "CAPAB SSJOIN NOQUIT BURST UNCONNECT TLS"
+                         " ZIP NICKIP NICKIPSTR TSMODE");
+    }
     else
     {
         sendto_one(cptr, "CAPAB SSJOIN NOQUIT BURST UNCONNECT DKEY"

--- a/src/s_bsd.c
+++ b/src/s_bsd.c
@@ -1985,7 +1985,7 @@ int connect_server(aConnect *aconn, aClient * by, struct hostent *hp)
 
         SSL_set_ex_data(cptr->ssl, mydata_index, aconn);
 
-        if (!safe_ssl_connect(cptr, cptr->fd))
+        if (!safe_ssl_connect(cptr))
         {
             sendto_realops_lev(DEBUG_LEV, "SSL_connect failed for %s", cptr->name);
             SSL_set_shutdown(cptr->ssl, SSL_RECEIVED_SHUTDOWN);

--- a/src/s_bsd.c
+++ b/src/s_bsd.c
@@ -869,6 +869,7 @@ int completed_connection(aClient * cptr)
         switch (verify_result)
         {
             case X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN:
+            case X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT:
             case X509_V_OK:
                 break;
             default:

--- a/src/s_conf.c
+++ b/src/s_conf.c
@@ -773,6 +773,7 @@ static int server_info[] =
     CONN_ZIP, 'Z',
     CONN_DKEY, 'E',
     CONN_HUB, 'H',
+    CONN_SSL, 'S',
     0, 0
 };
 

--- a/src/s_conf.c
+++ b/src/s_conf.c
@@ -773,7 +773,7 @@ static int server_info[] =
     CONN_ZIP, 'Z',
     CONN_DKEY, 'E',
     CONN_HUB, 'H',
-    CONN_SSL, 'S',
+    CONN_TLS, 'S',
     0, 0
 };
 
@@ -927,6 +927,15 @@ confadd_connect(cVar *vars[], int lnum)
             DupString(x->class_name, tmp->value);
         }
     }
+    
+    /* Check for conflicting encryption flags */
+    if((x->flags & CONN_DKEY) && (x->flags & CONN_TLS))
+    {
+        confparse_error("Conflicting encryption flags: E (Diffie-Hellman) and S (TLS) cannot be used together", lnum);
+        free_connect(x);
+        return -1;
+    }
+    
     if(!x->name)
     {
         confparse_error("Lacking name in connect block", lnum);

--- a/src/s_serv.c
+++ b/src/s_serv.c
@@ -995,7 +995,7 @@ m_connect(aClient *cptr, aClient *sptr, int parc, char *parv[])
     switch (retval = connect_server(aconn, sptr, NULL))
     {
         case 0:
-            if (aconn->flags & CONN_SSL) 
+            if (aconn->flags & CONN_TLS) 
                 sendto_one(sptr, ":%s NOTICE %s :*** Connecting to %s (TLS).",
                            me.name, parv[0], aconn->name);
             else

--- a/src/s_serv.c
+++ b/src/s_serv.c
@@ -995,8 +995,12 @@ m_connect(aClient *cptr, aClient *sptr, int parc, char *parv[])
     switch (retval = connect_server(aconn, sptr, NULL))
     {
         case 0:
-            sendto_one(sptr, ":%s NOTICE %s :*** Connecting to %s.",
-                       me.name, parv[0], aconn->name);
+            if (aconn->flags & CONN_SSL) 
+                sendto_one(sptr, ":%s NOTICE %s :*** Connecting to %s (TLS).",
+                           me.name, parv[0], aconn->name);
+            else
+                sendto_one(sptr, ":%s NOTICE %s :*** Connecting to %s.",
+                           me.name, parv[0], aconn->name);
             break;
         case -1:
             sendto_one(sptr, ":%s NOTICE %s :*** Couldn't connect to %s.",

--- a/src/s_serv.c
+++ b/src/s_serv.c
@@ -2510,6 +2510,8 @@ m_capab(aClient *cptr, aClient *sptr, int parc, char *parv[])
             SetUnconnect(cptr);
         else if (strcmp(parv[i], "DKEY") == 0)
             SetDKEY(cptr);
+        else if (strcmp(parv[i], "TLS") == 0)
+            SetTLS(cptr);
         else if (strcmp(parv[i], "ZIP") == 0)
             SetZipCapable(cptr);
 #ifdef NOQUIT

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -62,11 +62,11 @@ int ssl_init()
     SSLeay_add_ssl_algorithms();
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
     ircdssl_ctx = SSL_CTX_new(SSLv23_server_method());
-	server_ssl_ctx = SSL_CTX_new(SSLv23_client_method());
+    server_ssl_ctx = SSL_CTX_new(SSLv23_client_method());
 #else
     ircdssl_ctx = SSL_CTX_new(TLS_server_method());
-	server_ssl_ctx = SSL_CTX_new(TLS_client_method());
-	SSL_CTX_set_min_proto_version(server_ssl_ctx, TLS1_2_VERSION);
+    server_ssl_ctx = SSL_CTX_new(TLS_client_method());
+    SSL_CTX_set_min_proto_version(server_ssl_ctx, TLS1_2_VERSION);
 #endif
 
     if(!ircdssl_ctx)
@@ -81,7 +81,7 @@ int ssl_init()
         return 0;
     }
 
-	SSL_CTX_set_verify(server_ssl_ctx, SSL_VERIFY_PEER, ssl_verify_callback);
+    SSL_CTX_set_verify(server_ssl_ctx, SSL_VERIFY_PEER, ssl_verify_callback);
 
     if(SSL_CTX_use_certificate_chain_file(ircdssl_ctx, IRCDSSL_CPATH) <= 0)
     {
@@ -105,7 +105,7 @@ int ssl_init()
 	return 0;
     }
 
-	mydata_index = SSL_get_ex_new_index(0, "aConn data", NULL, NULL, NULL);
+    mydata_index = SSL_get_ex_new_index(0, "aConn data", NULL, NULL, NULL);
 
     return 1;
 }
@@ -457,7 +457,7 @@ int ssl_verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
 		if (!mycmp((const char *)cn, conn->name))
 		{
 			sendto_realops_lev(DEBUG_LEV, "SSL: Valid certificate cn: %s, name: %s", cn, conn->name);
-			 return 1; 
+			return 1; 
 		}
 		else 
 		{

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -154,11 +154,11 @@ int ssl_rehash()
     fclose(file);
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
-    if(!(temp_ircdssl_ctx = SSL_CTX_new(SSLv23_server_method())))
-	if (!(temp_server_ssl_ctx = SSL_CTX_new(SSLv23_client_method())))
+    if(!(temp_ircdssl_ctx = SSL_CTX_new(SSLv23_server_method())) ||
+       !(temp_server_ssl_ctx = SSL_CTX_new(SSLv23_client_method())))
 #else
-    if(!(temp_ircdssl_ctx = SSL_CTX_new(TLS_server_method())))
-	if (!(temp_server_ssl_ctx = SSL_CTX_new(TLS_client_method())))
+    if(!(temp_ircdssl_ctx = SSL_CTX_new(TLS_server_method())) ||
+       !(temp_server_ssl_ctx = SSL_CTX_new(TLS_client_method())))
 #endif
     {
 		abort_ssl_rehash(1);
@@ -451,10 +451,10 @@ int ssl_verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
 		if (!e) return preverify_ok;
 		ASN1_STRING *d = X509_NAME_ENTRY_get_data(e);
 		if (!d) return preverify_ok;
-		char *cn = ASN1_STRING_data(d);
+		const unsigned char *cn = ASN1_STRING_get0_data(d);
 		if (!cn) return preverify_ok;
 
-		if (!mycmp(cn, conn->name))
+		if (!mycmp((const char *)cn, conn->name))
 		{
 			sendto_realops_lev(DEBUG_LEV, "SSL: Valid certificate cn: %s, name: %s", cn, conn->name);
 			 return 1; 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -165,6 +165,7 @@ int ssl_rehash()
 		SSL_CTX_set_verify(temp_server_ssl_ctx, SSL_VERIFY_PEER, ssl_verify_callback);
 	}
 #endif
+    if (!temp_ircdssl_ctx || !temp_server_ssl_ctx)
     {
 		abort_ssl_rehash(1);
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -440,7 +440,7 @@ int ssl_verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
 	depth = X509_STORE_CTX_get_error_depth(ctx);
 
 	if (!preverify_ok && (err != X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN
-	    || err != X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT))
+	    && err != X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT))
 	{
 		sendto_realops_lev(DEBUG_LEV, "SSL: verify error:num=%d:%s:depth=%d\n", err,
 			X509_verify_cert_error_string(err), depth);
@@ -464,7 +464,7 @@ int ssl_verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
 					if (!mycmp(common_name_str, conn->name))
 					{
 						sendto_realops_lev(DEBUG_LEV, "SSL: Valid certificate cn: %s, name: %s", common_name_str, conn->name);
-						return 1;
+						return X509_V_OK;
 					}
 					else
 					{

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -217,7 +217,7 @@ int ssl_rehash()
 
 static int fatal_ssl_error(int, int, aClient *);
 
-int safe_ssl_connect(aClient *acptr, int fd)
+int safe_ssl_connect(aClient *acptr)
 {
 	int ssl_err;
 	if ((ssl_err = SSL_connect(acptr->ssl)) <= 0)
@@ -438,8 +438,9 @@ int ssl_verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
 	if (!preverify_ok && err != X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN)
 	{
 		char buf[256];
-		sendto_realops_lev(DEBUG_LEV, "SSL: verify error:num=%d:%s:depth=%d:%s\n", err,
 		X509_verify_cert_error_string(err), depth, buf);
+		sendto_realops_lev(DEBUG_LEV, "SSL: verify error:num=%d:%s:depth=%d:%s\n", err,
+		
 		return preverify_ok;
 	} else if (depth == 0) {
 		int lastpos = -1;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -28,9 +28,10 @@
 #ifdef USE_SSL
 
 
-#define SAFE_SSL_READ	1
-#define SAFE_SSL_WRITE	2
-#define SAFE_SSL_ACCEPT	3
+#define SAFE_SSL_READ	 1
+#define SAFE_SSL_WRITE	 2
+#define SAFE_SSL_ACCEPT	 3
+#define SAFE_SSL_CONNECT 4
 
 extern int errno;
 
@@ -80,7 +81,7 @@ int ssl_init()
         return 0;
     }
 
-	SSL_CTX_set_verify(serverssl_ctx, SSL_VERIFY_PEER, ssl_verify_callback);
+	SSL_CTX_set_verify(server_ssl_ctx, SSL_VERIFY_PEER, ssl_verify_callback);
 
     if(SSL_CTX_use_certificate_chain_file(ircdssl_ctx, IRCDSSL_CPATH) <= 0)
     {

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -35,7 +35,9 @@
 extern int errno;
 
 SSL_CTX *ircdssl_ctx;
+SSL_CTX *server_ssl_ctx;
 int ssl_capable = 0;
+int mydata_index = 0;
 
 int ssl_init()
 {
@@ -59,8 +61,11 @@ int ssl_init()
     SSLeay_add_ssl_algorithms();
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
     ircdssl_ctx = SSL_CTX_new(SSLv23_server_method());
+	server_ssl_ctx = SSL_CTX_new(SSLv23_client_method());
 #else
     ircdssl_ctx = SSL_CTX_new(TLS_server_method());
+	server_ssl_ctx = SSL_CTX_new(TLS_client_method());
+	SSL_CTX_set_min_proto_version(server_ssl_ctx, TLS1_2_VERSION);
 #endif
 
     if(!ircdssl_ctx)
@@ -68,6 +73,14 @@ int ssl_init()
 	ERR_print_errors_fp(stderr);
 	return 0;
     }
+
+    if(!server_ssl_ctx)
+    {
+        ERR_print_errors_fp(stderr);
+        return 0;
+    }
+
+	SSL_CTX_set_verify(serverssl_ctx, SSL_VERIFY_PEER, ssl_verify_callback);
 
     if(SSL_CTX_use_certificate_chain_file(ircdssl_ctx, IRCDSSL_CPATH) <= 0)
     {
@@ -90,6 +103,8 @@ int ssl_init()
 	SSL_CTX_free(ircdssl_ctx);
 	return 0;
     }
+
+	mydata_index = SSL_get_ex_new_index(0, "aConnn data", NULL, NULL, NULL);
 
     return 1;
 }
@@ -117,6 +132,7 @@ int ssl_rehash()
 {
     FILE *file;
 	SSL_CTX *temp_ircdssl_ctx;
+	SSL_CTX *temp_server_ssl_ctx;
 
     if(!(file = fopen(IRCDSSL_CPATH,"r")))
     {
@@ -138,8 +154,10 @@ int ssl_rehash()
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
     if(!(temp_ircdssl_ctx = SSL_CTX_new(SSLv23_server_method())))
+	if (!(temp_server_ssl_ctx = SSL_CTX_new(SSLv23_client_method())))
 #else
     if(!(temp_ircdssl_ctx = SSL_CTX_new(TLS_server_method())))
+	if (!(temp_server_ssl_ctx = SSL_CTX_new(TLS_client_method())))
 #endif
     {
 		abort_ssl_rehash(1);
@@ -185,10 +203,38 @@ int ssl_rehash()
 
 	ircdssl_ctx = temp_ircdssl_ctx;
 
+	if (server_ssl_ctx)
+	{
+		SSL_CTX_free(server_ssl_ctx);
+	}
+	server_ssl_ctx = temp_server_ssl_ctx;
+	SSL_CTX_set_min_proto_version(server_ssl_ctx, TLS1_2_VERSION);
+	SSL_CTX_set_verify(server_ssl_ctx, SSL_VERIFY_PEER, ssl_verify_callback);
+
     return 1;
 }
 
 static int fatal_ssl_error(int, int, aClient *);
+
+int safe_ssl_connect(aClient *acptr, int fd)
+{
+	int ssl_err;
+	if ((ssl_err = SSL_connect(acptr->ssl)) <= 0)
+	{
+		switch (ssl_err = SSL_get_error(acptr->ssl, ssl_err))
+		{
+			case SSL_ERROR_WANT_READ:
+			case SSL_ERROR_WANT_WRITE:
+				return 1;
+			default:
+			 return fatal_ssl_error(ssl_err, SAFE_SSL_CONNECT, acptr);
+		}
+
+		return -1; // not reached
+	}
+
+	return 1;
+}
 
 int safe_ssl_read(aClient *acptr, void *buf, int sz)
 {
@@ -303,6 +349,9 @@ static int fatal_ssl_error(int ssl_error, int where, aClient *sptr)
 	case SAFE_SSL_ACCEPT:
 	    ssl_func = "SSL_accept()";
 	    break;
+	case SAFE_SSL_CONNECT:
+	    ssl_func = "SSL_connect()";
+	    break;
 	default:
 	    ssl_func = "undefined SSL func [this is a bug] report to coders@dal.net";
     }
@@ -371,5 +420,54 @@ static int fatal_ssl_error(int ssl_error, int where, aClient *sptr)
     sptr->sockerr = IRCERR_SSL;
     sptr->flags |= FLAGS_DEADSOCKET;
     return -1;
+}
+
+int ssl_verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
+{
+	char buf[256];
+	X509 *cert;
+	SSL *ssl;
+	int err, depth;
+	aConnect *conn;
+
+	ssl = X509_STORE_CTX_get_ex_data(ctx, SSL_get_ex_data_X509_STORE_CTX_idx());
+	conn = SSL_get_ex_data(ssl, mydata_index);
+	cert = X509_STORE_CTX_get_current_cert(ctx);
+	err = X509_STORE_CTX_get_error(ctx);
+	depth = X509_STORE_CTX_get_error_depth(ctx);
+
+	X509_NAME_oneline(X509_get_subject_name(cert), buf, 256);
+	sendto_realops_lev(DEBUG_LEV, "Got subject name [%d]: %s", depth, buf);
+
+	if (!preverify_ok && err != X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN)
+	{
+		sendto_realops_lev(DEBUG_LEV, "SSL: verify error:num=%d:%s:depth=%d:%s\n", err,
+			X509_verify_cert_error_string(err), depth, buf);
+			return preverify_ok;
+	} else if (depth == 0) {
+		X509_NAME *subj = X509_get_subject_name(cert);
+		if (!subj) return preverify_ok;
+		X509_NAME_ENTRY *e = X509_NAME_get_entry(subj, 5);
+		if (!e) return preverify_ok;
+		ASN1_STRING *d = X509_NAME_ENTRY_get_data(e);
+		if (!d) return preverify_ok;
+		char *cn = ASN1_STRING_data(d);
+		if (!cn) return preverify_ok;
+
+		if (!mycmp(cn, conn->name))
+		{
+			sendto_realops_lev(DEBUG_LEV, "SSL: Valid certificate cn: %s, name: %s", cn, conn->name);
+			 return 1; 
+		}
+		else 
+		{
+			sendto_realops_lev(DEBUG_LEV, "SSL: Subject and connection name mismatch %s : %s", cn, conn->name);
+			return preverify_ok;
+		}
+	}
+	else
+	{
+		return 1;
+	}
 }
 #endif

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -437,9 +437,10 @@ int ssl_verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
 
 	if (!preverify_ok && err != X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN)
 	{
+		char buf[256];
 		sendto_realops_lev(DEBUG_LEV, "SSL: verify error:num=%d:%s:depth=%d:%s\n", err,
-			X509_verify_cert_error_string(err), depth, buf);
-			return preverify_ok;
+		X509_verify_cert_error_string(err), depth, buf);
+		return preverify_ok;
 	} else if (depth == 0) {
 		int lastpos = -1;
 		X509_NAME *subject_name = X509_get_subject_name(cert);
@@ -451,7 +452,7 @@ int ssl_verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
 				ASN1_STRING *cn_data = X509_NAME_ENTRY_get_data(cn_entry);
 				if (cn_data)
 				{
-					const char *common_name_str = (const char *)ASN1_STRING_data(cn_data);
+					const char *common_name_str = (const char *)ASN1_STRING_get0_data(cn_data);
 
 					if (!common_name_str) return preverify_ok;
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -105,7 +105,7 @@ int ssl_init()
 	return 0;
     }
 
-	mydata_index = SSL_get_ex_new_index(0, "aConnn data", NULL, NULL, NULL);
+	mydata_index = SSL_get_ex_new_index(0, "aConn data", NULL, NULL, NULL);
 
     return 1;
 }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -231,7 +231,6 @@ int safe_ssl_connect(aClient *acptr, int fd)
 			 return fatal_ssl_error(ssl_err, SAFE_SSL_CONNECT, acptr);
 		}
 
-		return -1; // not reached
 	}
 
 	return 1;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -159,6 +159,8 @@ int ssl_rehash()
 #else
     if(!(temp_ircdssl_ctx = SSL_CTX_new(TLS_server_method())) ||
        !(temp_server_ssl_ctx = SSL_CTX_new(TLS_client_method())))
+	   SSL_CTX_set_min_proto_version(temp_server_ssl_ctx, TLS1_2_VERSION);
+	   SSL_CTX_set_verify(temp_server_ssl_ctx, SSL_VERIFY_PEER, ssl_verify_callback);
 #endif
     {
 		abort_ssl_rehash(1);
@@ -209,8 +211,6 @@ int ssl_rehash()
 		SSL_CTX_free(server_ssl_ctx);
 	}
 	server_ssl_ctx = temp_server_ssl_ctx;
-	SSL_CTX_set_min_proto_version(server_ssl_ctx, TLS1_2_VERSION);
-	SSL_CTX_set_verify(server_ssl_ctx, SSL_VERIFY_PEER, ssl_verify_callback);
 
     return 1;
 }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -440,9 +440,8 @@ int ssl_verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
 	if (!preverify_ok && err != X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN)
 	{
 		char buf[256];
-		X509_verify_cert_error_string(err), depth, buf);
-		sendto_realops_lev(DEBUG_LEV, "SSL: verify error:num=%d:%s:depth=%d:%s\n", err,
-		
+		sendto_realops_lev(DEBUG_LEV, "SSL: verify error:num=%d:%s:depth=%d\n", err,
+			X509_verify_cert_error_string(err), depth);
 		return preverify_ok;
 	} else if (depth == 0) {
 		int lastpos = -1;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -159,8 +159,10 @@ int ssl_rehash()
 #else
     if(!(temp_ircdssl_ctx = SSL_CTX_new(TLS_server_method())) ||
        !(temp_server_ssl_ctx = SSL_CTX_new(TLS_client_method())))
-	   SSL_CTX_set_min_proto_version(temp_server_ssl_ctx, TLS1_2_VERSION);
-	   SSL_CTX_set_verify(temp_server_ssl_ctx, SSL_VERIFY_PEER, ssl_verify_callback);
+    {
+        SSL_CTX_set_min_proto_version(temp_server_ssl_ctx, TLS1_2_VERSION);
+        SSL_CTX_set_verify(temp_server_ssl_ctx, SSL_VERIFY_PEER, ssl_verify_callback);
+    }
 #endif
     {
 		abort_ssl_rehash(1);

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -464,7 +464,7 @@ int ssl_verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
 					if (!mycmp(common_name_str, conn->name))
 					{
 						sendto_realops_lev(DEBUG_LEV, "SSL: Valid certificate cn: %s, name: %s", common_name_str, conn->name);
-						return X509_V_OK;
+						return 1;
 					}
 					else
 					{
@@ -477,11 +477,8 @@ int ssl_verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
 		}
 		sendto_realops("Could not connect to %s using TLS: No common name found in certificate", conn->name);
 		sendto_realops_lev(DEBUG_LEV, "SSL: No common name found in certificate");
-		return preverify_ok;
 	}
-	else
-	{
-		return preverify_ok;
-	}
+
+	return preverify_ok;
 }
 #endif

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -154,15 +154,16 @@ int ssl_rehash()
     fclose(file);
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
-    if(!(temp_ircdssl_ctx = SSL_CTX_new(SSLv23_server_method())) ||
-       !(temp_server_ssl_ctx = SSL_CTX_new(SSLv23_client_method())))
+    temp_ircdssl_ctx = SSL_CTX_new(SSLv23_server_method());
+    temp_server_ssl_ctx = SSL_CTX_new(SSLv23_client_method());
 #else
-    if(!(temp_ircdssl_ctx = SSL_CTX_new(TLS_server_method())) ||
-       !(temp_server_ssl_ctx = SSL_CTX_new(TLS_client_method())))
-    {
-        SSL_CTX_set_min_proto_version(temp_server_ssl_ctx, TLS1_2_VERSION);
-        SSL_CTX_set_verify(temp_server_ssl_ctx, SSL_VERIFY_PEER, ssl_verify_callback);
-    }
+    temp_ircdssl_ctx = SSL_CTX_new(TLS_server_method());
+    temp_server_ssl_ctx = SSL_CTX_new(TLS_client_method());
+	if (temp_server_ssl_ctx)
+	{
+		SSL_CTX_set_min_proto_version(temp_server_ssl_ctx, TLS1_2_VERSION);
+		SSL_CTX_set_verify(temp_server_ssl_ctx, SSL_VERIFY_PEER, ssl_verify_callback);
+	}
 #endif
     {
 		abort_ssl_rehash(1);
@@ -439,7 +440,6 @@ int ssl_verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
 
 	if (!preverify_ok && err != X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN)
 	{
-		char buf[256];
 		sendto_realops_lev(DEBUG_LEV, "SSL: verify error:num=%d:%s:depth=%d\n", err,
 			X509_verify_cert_error_string(err), depth);
 		return preverify_ok;


### PR DESCRIPTION
This change maintains support for DH encryption but also allows the use of the S connection flag to set up TLS instead.